### PR TITLE
'fix' Clear All chat history button should be disable where there is…

### DIFF
--- a/ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryPanel.tsx
+++ b/ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryPanel.tsx
@@ -49,7 +49,7 @@ export function ChatHistoryPanel(_props: ChatHistoryPanelProps) {
   const [hideClearAllDialog, { toggle: toggleClearAllDialog }] = useBoolean(true)
   const [clearing, setClearing] = React.useState(false)
   const [clearingError, setClearingError] = React.useState(false)
-
+  const hasChatHistory = appStateContext?.state.chatHistory && appStateContext.state.chatHistory.length > 0;
   const clearAllDialogContentProps = {
     type: DialogType.close,
     title: !clearingError ? 'Are you sure you want to clear all chat history?' : 'Error deleting all of chat history',
@@ -67,7 +67,7 @@ export function ChatHistoryPanel(_props: ChatHistoryPanelProps) {
   }
 
   const menuItems: IContextualMenuItem[] = [
-    { key: 'clearAll', text: 'Clear all chat history', iconProps: { iconName: 'Delete' } }
+    { key: 'clearAll', text: 'Clear all chat history',disabled: !hasChatHistory, iconProps: { iconName: 'Delete' }}
   ]
 
   const handleHistoryClick = () => {


### PR DESCRIPTION

Notice when you launch the experience the user arrives at this landing page:

Launch the experience
Click a customer to start a chat session
Ask a question and get a nice response
On the right side panel, choose the ellipses near Chat History
Select Clear all chat history then confirm with [Clear all]
All histories are deleted

We are disabling the **_clear all history_** option disabled now.

<img width="949" alt="image" src="https://github.com/user-attachments/assets/ac0099d6-3e5d-4330-a579-e8c5f290c475">
 
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
 
- [ ] Yes

- [X] No
 
<!-- Please prefix your PR title with one of the following:

  * `feat`: A new feature

  * `fix`: A bug fix

  * `docs`: Documentation only changes

  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)

  * `refactor`: A code change that neither fixes a bug nor adds a feature

  * `perf`: A code change that improves performance

  * `test`: Adding missing tests or correcting existing tests

  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)

  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)

  * `chore`: Other changes that don't modify src or test files

  * `revert`: Reverts a previous commit

  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.

-->
 
## How to Test

*  Get the code
 
```

git clone [repo-address]

cd [repo-name]

git checkout [branch-name]

npm install

```
 
* Test the code
<!-- Add steps to run the tests suite and/or manually test -->

```

```
 
## What to Check

Verify that the following are valid:

Clear All chat history should be disable when there is no history added.

Validate CSS.

* ...
 
## Other Information
<!-- Add any other helpful information that may be needed here. -->

 