### PR TITLE
Fix for There is no appropriate response when attempting to generate an unethical question on the Articles and Grants pages (Handle Exception)

### DIFF
--- a/ResearchAssistant/App/app.py
+++ b/ResearchAssistant/App/app.py
@@ -301,7 +301,7 @@ def stream_with_data(body, headers, endpoint, history_metadata={}):
                                 yield format_as_ndjson({"error": "We're currently experiencing a high number of requests for the service you're trying to access. Please wait a moment and try again."})
                             else:
                                 yield format_as_ndjson({"error": "An error occurred. Please try again. If the problem persists, please contact the site administrator."})
-
+                            continue
                         response["id"] = lineJson["id"]
                         response["model"] = lineJson["model"]
                         response["created"] = lineJson["created"]

--- a/ResearchAssistant/App/app.py
+++ b/ResearchAssistant/App/app.py
@@ -287,8 +287,21 @@ def stream_with_data(body, headers, endpoint, history_metadata={}):
                                 continue
 
                         if 'error' in lineJson:
-                            yield format_as_ndjson(lineJson)
-                        
+                            error_code_value = lineJson.get('error', {}).get('code', '')
+                            error_message = format_as_ndjson(lineJson)
+                            inner_error_code_value = extract_value('code', error_message)
+                            inner_error_status_value = extract_value('status', error_message)
+                            if inner_error_code_value == 'content_filter' and inner_error_status_value == '400':
+                                response["choices"][0]["messages"].append({
+                                    "role": "assistant",
+                                    "content": "I am sorry, I don’t have this information in the knowledge repository. Please ask another question."
+                                })
+                                yield format_as_ndjson(response)
+                            elif error_code_value == '429' or inner_error_code_value == '429':
+                                yield format_as_ndjson({"error": "We're currently experiencing a high number of requests for the service you're trying to access. Please wait a moment and try again."})
+                            else:
+                                yield format_as_ndjson({"error": "An error occurred. Please try again. If the problem persists, please contact the site administrator."})
+
                         response["id"] = lineJson["id"]
                         response["model"] = lineJson["model"]
                         response["created"] = lineJson["created"]

--- a/ResearchAssistant/App/frontend/src/pages/chat/Chat.tsx
+++ b/ResearchAssistant/App/frontend/src/pages/chat/Chat.tsx
@@ -158,7 +158,7 @@ const Chat = ({ chatType }: Props) => {
     setMessages(conversation.messages)
 
     const request: ConversationRequest = {
-      messages: [...conversation.messages.filter((answer) => answer.role !== ERROR)],
+      messages: [...conversation.messages.filter((answer) => answer.hasOwnProperty('content') && answer.hasOwnProperty('role') && answer.role !== ERROR)],
       index_name: String(appStateContext?.state.sidebarSelection)
     }
 
@@ -190,7 +190,18 @@ const Chat = ({ chatType }: Props) => {
               })
               runningText = ''
             }
-            catch { }
+            catch {
+              if (typeof result.error === 'string') {
+                let errorMessage = result.error
+                let errorChatMsg: ChatMessage = {
+                  id: uuid(),
+                  role: ERROR,
+                  content: errorMessage,
+                  date: new Date().toISOString()
+                }
+                assistantMessage = errorChatMsg
+              }
+            }
           })
         }
         conversation.messages.push(toolMessage, assistantMessage)


### PR DESCRIPTION
Fix for There is no appropriate response when attempting to generate an unethical question on the Articles and Grants pages (Handle Exception)

**Sample Output:**
Unethical Question:
<img width="920" alt="Unethical Question" src="https://github.com/user-attachments/assets/468f9d0c-f245-44d2-97af-75a370132b28">

Rate Limit Error:
<img width="605" alt="ratelimit error" src="https://github.com/user-attachments/assets/fda614e0-f3ec-4bd2-802e-4b2f2d1b80b9">

General Exception: 
<img width="568" alt="General Exception" src="https://github.com/user-attachments/assets/caf4195c-d3d7-4f8e-81d8-6497fc217fc2">
