### PR TITLE
Fix: Chatbot Client Context Recognition and Asset Data Consistency Bugs

### DIFF
--- a/ClientAdvisor/AzureFunction/function_app.py
+++ b/ClientAdvisor/AzureFunction/function_app.py
@@ -261,6 +261,8 @@ async def stream_openai_text(req: Request) -> StreamingResponse:
 
     system_message = '''you are a helpful assistant to a wealth advisor. 
     Do not answer any questions not related to wealth advisors queries.
+    Always recognize and respond to the selected client by their full name or common variations (e.g., "Karen" and "Karen Berg" should be treated as the same client if Karen Berg is selected). 
+    Ensure responses are consistent and up-to-date, clearly stating the date of the data to avoid confusion
     If the client name and client id do not match, only return - Please only ask questions about the selected client or select another client to inquire about their details. do not return any other information.
     Only use the client name returned from database in the response.
     If you cannot answer the question, always return - I cannot answer this question from the data available. Please rephrase or add more details.


### PR DESCRIPTION
**Bug 5549 :Chatbot can give competing answers about freshness of client asset data**

**Before Fix:** (Recent dates are different in both the responses)
![image](https://github.com/user-attachments/assets/c7230d9b-cffe-4936-8b2f-5a777490ffdb)

**After Fix:** (Recent dates are same now in all the responses)
Have made the necessary fix and now the bug is solved 
![image](https://github.com/user-attachments/assets/b6e89717-360d-4e08-abbe-fd7f12ce683e)


**Bug 5602:Chatbot cannot distinguish between "this client" and a client mentioned by name**

**Before Fix:** (AI is confused b/w this and client name)
![image](https://github.com/user-attachments/assets/7abb57c5-1a12-4029-a8ca-4d5021cd40b0)

**After Fix:** (AI is able to identify this and client name as same now)
have made the changes below is the screenshot attached
![image](https://github.com/user-attachments/assets/e536551c-43f2-49f2-a4d7-b97fb373b0ea)
