### PR TITLE
Fix: Updated the system message to accurately fetch data for upcoming scheduled meetings.

### DIFF
--- a/ClientAdvisor/AzureFunction/function_app.py
+++ b/ClientAdvisor/AzureFunction/function_app.py
@@ -100,6 +100,7 @@ class ChatWithDataPlugin:
         Do not include assets values unless asked for.
         Always use ClientId = {clientid} in the query filter.
         Always return client name in the query.
+        Always retrieve and provide information about client meetings scheduled for future dates, including the scheduled time in the query.
         Only return the generated sql query. do not return anything else''' 
         try:
 
@@ -261,6 +262,7 @@ async def stream_openai_text(req: Request) -> StreamingResponse:
 
     system_message = '''you are a helpful assistant to a wealth advisor. 
     Do not answer any questions not related to wealth advisors queries.
+    Always provide information about client meetings only for future dates, including the scheduled time.
     Always recognize and respond to the selected client by their full name or common variations (e.g., "Karen" and "Karen Berg" should be treated as the same client if Karen Berg is selected). 
     Ensure responses are consistent and up-to-date, clearly stating the date of the data to avoid confusion
     If the client name and client id do not match, only return - Please only ask questions about the selected client or select another client to inquire about their details. do not return any other information.


### PR DESCRIPTION
**Bug 5292 - Left panel shows an upcoming scheduled meeting, but chat responses says we have none**

**Before fix:** (Dates were not coming properly)

<img width="916" alt="Screenshot 2024-08-20 095718" src="https://github.com/user-attachments/assets/13f55f55-5837-4f66-9231-8827b4d385f8">

![image](https://github.com/user-attachments/assets/f28bf054-f170-4a29-a3a9-23b035bc6252)




Note: Occasionally, it also responded with: **"I cannot provide an answer based on the available data. Please rephrase your question or provide more details"** even when data was available.

**After Fix:** (Data is coming properly with proper date and time)

<img width="919" alt="image" src="https://github.com/user-attachments/assets/96e3e6d5-3d2c-450c-a0ec-f506e8a8f7af">

<img width="929" alt="image" src="https://github.com/user-attachments/assets/44c706b1-44d7-4845-afb9-744125d3b450">


