### PR TITLE
fix 24hrs time format chat response

### DIFF
--- a/ClientAdvisor/AzureFunction/function_app.py
+++ b/ClientAdvisor/AzureFunction/function_app.py
@@ -100,6 +100,7 @@ class ChatWithDataPlugin:
         Do not include assets values unless asked for.
         Always use ClientId = {clientid} in the query filter.
         Always return client name in the query.
+        Always return time in "HH:mm" format for the client meetings in response.
         Always retrieve and provide information about client meetings scheduled for future dates, including the scheduled time in the query.
         Only return the generated sql query. do not return anything else''' 
         try:
@@ -267,6 +268,7 @@ async def stream_openai_text(req: Request) -> StreamingResponse:
     Ensure responses are consistent and up-to-date, clearly stating the date of the data to avoid confusion
     If the client name and client id do not match, only return - Please only ask questions about the selected client or select another client to inquire about their details. do not return any other information.
     Only use the client name returned from database in the response.
+    if asked, summarize each call transcripts then always return all call transcript's summary for that client.
     If you cannot answer the question, always return - I cannot answer this question from the data available. Please rephrase or add more details.
     ** Remove any client identifiers or ids or numbers or ClientId in the final response.
     '''

--- a/ClientAdvisor/AzureFunction/function_app.py
+++ b/ClientAdvisor/AzureFunction/function_app.py
@@ -3,7 +3,6 @@ import openai
 from azurefunctions.extensions.http.fastapi import Request, StreamingResponse
 import asyncio
 import os
-
 from typing import Annotated
 
 from semantic_kernel.connectors.ai.function_call_behavior import FunctionCallBehavior
@@ -18,7 +17,6 @@ from semantic_kernel.functions.kernel_arguments import KernelArguments
 from semantic_kernel.functions.kernel_function_decorator import kernel_function
 from semantic_kernel.kernel import Kernel
 import pymssql
-
 # Azure Function App
 app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
 
@@ -268,7 +266,6 @@ async def stream_openai_text(req: Request) -> StreamingResponse:
     Ensure responses are consistent and up-to-date, clearly stating the date of the data to avoid confusion
     If the client name and client id do not match, only return - Please only ask questions about the selected client or select another client to inquire about their details. do not return any other information.
     Only use the client name returned from database in the response.
-    if asked, summarize each call transcripts then always return all call transcript's summary for that client.
     If you cannot answer the question, always return - I cannot answer this question from the data available. Please rephrase or add more details.
     ** Remove any client identifiers or ids or numbers or ClientId in the final response.
     '''

--- a/ClientAdvisor/AzureFunction/function_app.py
+++ b/ClientAdvisor/AzureFunction/function_app.py
@@ -3,6 +3,7 @@ import openai
 from azurefunctions.extensions.http.fastapi import Request, StreamingResponse
 import asyncio
 import os
+
 from typing import Annotated
 
 from semantic_kernel.connectors.ai.function_call_behavior import FunctionCallBehavior
@@ -17,6 +18,7 @@ from semantic_kernel.functions.kernel_arguments import KernelArguments
 from semantic_kernel.functions.kernel_function_decorator import kernel_function
 from semantic_kernel.kernel import Kernel
 import pymssql
+
 # Azure Function App
 app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
 

--- a/ClientAdvisor/AzureFunction/function_app.py
+++ b/ClientAdvisor/AzureFunction/function_app.py
@@ -160,6 +160,7 @@ class ChatWithDataPlugin:
         query = question
         system_message = '''You are an assistant who provides wealth advisors with helpful information to prepare for client meetings. 
         You have access to the client’s meeting call transcripts. 
+        Always return time in "HH:mm" format for the client in response.
         You can use this information to answer questions about the clients'''
 
         completion = client.chat.completions.create(


### PR DESCRIPTION
Notice when you launch the experience the user arrives at this landing page:

Launch the experience
Show in this screenshot. Left panel has times such as 4:00PM but chatbot responses are showing times as 19:00 hours. Seems inconsistent and should all be the same.


![image](https://github.com/user-attachments/assets/70b565bd-ed73-4118-acb4-edd8b949ee19)
 
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
 
- [ ] Yes

- [X] No
 
<!-- Please prefix your PR title with one of the following:

  * `feat`: A new feature

  * `fix`: A bug fix

  * `docs`: Documentation only changes

  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)

  * `refactor`: A code change that neither fixes a bug nor adds a feature

  * `perf`: A code change that improves performance

  * `test`: Adding missing tests or correcting existing tests

  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)

  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)

  * `chore`: Other changes that don't modify src or test files

  * `revert`: Reverts a previous commit

  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.

-->
 
## How to Test

*  Get the code
 
```

git clone [repo-address]

cd [repo-name]

git checkout [branch-name]

npm install

```
 
* Test the code
<!-- Add steps to run the tests suite and/or manually test -->

```

```
 
## What to Check

Verify that the following are valid:

time format should be same for side panel and chat response
Validate CSS.

* ...
 
## Other Information
<!-- Add any other helpful information that may be needed here. -->

 