### PR TITLE
fix: Disabling the clear all history button when loading

### DIFF
--- a/ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryPanel.tsx
+++ b/ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryPanel.tsx
@@ -26,7 +26,9 @@ import ChatHistoryList from './ChatHistoryList'
 
 import styles from './ChatHistoryPanel.module.css'
 
-interface ChatHistoryPanelProps {}
+interface ChatHistoryPanelProps {
+  isLoading: boolean
+}
 
 export enum ChatHistoryPanelTabs {
   History = 'History'
@@ -44,6 +46,7 @@ const commandBarStyle: ICommandBarStyles = {
 const commandBarButtonStyle: Partial<IStackStyles> = { root: { height: '50px' } }
 
 export function ChatHistoryPanel(_props: ChatHistoryPanelProps) {
+  const { isLoading} = _props
   const appStateContext = useContext(AppStateContext)
   const [showContextualMenu, setShowContextualMenu] = React.useState(false)
   const [hideClearAllDialog, { toggle: toggleClearAllDialog }] = useBoolean(true)
@@ -67,7 +70,7 @@ export function ChatHistoryPanel(_props: ChatHistoryPanelProps) {
   }
 
   const menuItems: IContextualMenuItem[] = [
-    { key: 'clearAll', text: 'Clear all chat history',disabled: !hasChatHistory, iconProps: { iconName: 'Delete' }}
+    { key: 'clearAll', text: 'Clear all chat history',disabled: (!hasChatHistory || isLoading), iconProps: { iconName: 'Delete' }}
   ]
 
   const handleHistoryClick = () => {

--- a/ClientAdvisor/App/frontend/src/pages/chat/Chat.tsx
+++ b/ClientAdvisor/App/frontend/src/pages/chat/Chat.tsx
@@ -938,7 +938,7 @@ const Chat = () => {
             </Stack.Item>
           )}
           {appStateContext?.state.isChatHistoryOpen &&
-            appStateContext?.state.isCosmosDBAvailable?.status !== CosmosDBStatus.NotConfigured && <ChatHistoryPanel />}
+            appStateContext?.state.isCosmosDBAvailable?.status !== CosmosDBStatus.NotConfigured && <ChatHistoryPanel isLoading={isLoading} />}
         </Stack>
       )}
     </div>


### PR DESCRIPTION
_Conversation not found error for delete all chat history during response loading_

While generating AI response we will disable to avoid issues 

- Disabled clear all chat history button from menu

![image](https://github.com/user-attachments/assets/7596cb07-8d4b-47e7-b70a-1b35da10feda)

- Enabled when not generating

![image](https://github.com/user-attachments/assets/2c287b83-3ae5-49f1-9763-9d3185def274)