### PR TITLE
fix: Feature add-on - Chat returns - Research if we can display output data in a table format

### DIFF
--- a/ClientAdvisor/AzureFunction/function_app.py
+++ b/ClientAdvisor/AzureFunction/function_app.py
@@ -259,13 +259,21 @@ async def stream_openai_text(req: Request) -> StreamingResponse:
     settings.max_tokens = 800
     settings.temperature = 0
 
+    # Read the HTML file
+    with open("table.html", "r") as file:
+        html_content = file.read()
+
     system_message = '''you are a helpful assistant to a wealth advisor. 
     Do not answer any questions not related to wealth advisors queries.
     If the client name and client id do not match, only return - Please only ask questions about the selected client or select another client to inquire about their details. do not return any other information.
     Only use the client name returned from database in the response.
     If you cannot answer the question, always return - I cannot answer this question from the data available. Please rephrase or add more details.
     ** Remove any client identifiers or ids or numbers or ClientId in the final response.
+    For any questions requiring a table, always render the table using the following HTML format:
     '''
+ 
+    # Make sure you have the system prompt always at the end to append the html content.
+    system_message += html_content
 
     user_query = query.replace('?',' ')
 

--- a/ClientAdvisor/AzureFunction/table.html
+++ b/ClientAdvisor/AzureFunction/table.html
@@ -1,0 +1,11 @@
+ <!-- Include the table here -->
+    <table style="border: 1px solid #C8C6C4; width: 100%; border-collapse: collapse; margin: 20px 0; font-size: 1em; font-family: Segoe UI">
+        <tr>
+            <th style="background-color: #F3F2F1; padding: 12px 15px; border: 1px solid #ddd; text-align: left;">Header 1</th>
+            <th style="background-color: #F3F2F1; padding: 12px 15px; border: 1px solid #ddd; text-align: left;">Header 2</th>
+        </tr>
+        <tr>
+            <td style="padding: 12px 15px; border: 1px solid #ddd; text-align: left; color:#797775;">Data 1</td>
+            <td style="padding: 12px 15px; border: 1px solid #ddd; text-align: left; color:#797775;">Data 2</td>
+        </tr>
+    </table>


### PR DESCRIPTION
[Bug: https://dev.azure.com/CSACTOSOL/CSA%20Solutioning/_workitems/edit/7014

As a user,
I want to view the output data in table format for table format related questions,
So that its clear to have a better chat experience in BYOc- Client Advisor.

Notes:
ENG team: Research what is possible ways to output the data in table format.
Design team: Design the table format accordingly.

Acceptance Criteria:
Chat returns: output data needs to be in table format in the chat area for the table format related questions in BYOc-Client Advisor.

Please refer the below screenshots:
![image](https://github.com/user-attachments/assets/453fead3-ec81-40ec-b93b-2b0e71d37d5c)
![image](https://github.com/user-attachments/assets/9bbad094-e02b-4127-8dd2-1b45dc64490e)
![image](https://github.com/user-attachments/assets/4d230c1d-726a-44a4-a18e-33f6b63ecf4f)
![image](https://github.com/user-attachments/assets/bade6ef8-8ae0-4a63-b7e2-f702fcf9c60b)


