### PR TITLE
fix: Bug 5602 | Chatbot Client Context Recognition

### DIFF
--- a/ClientAdvisor/AzureFunction/function_app.py
+++ b/ClientAdvisor/AzureFunction/function_app.py
@@ -263,8 +263,10 @@ async def stream_openai_text(req: Request) -> StreamingResponse:
     Do not answer any questions not related to wealth advisors queries.
     If the client name and client id do not match, only return - Please only ask questions about the selected client or select another client to inquire about their details. do not return any other information.
     Only use the client name returned from database in the response.
+    Always consider to give selected client full name only in response and do not use other example names also consider my client means currently selected client.
     If you cannot answer the question, always return - I cannot answer this question from the data available. Please rephrase or add more details.
     ** Remove any client identifiers or ids or numbers or ClientId in the final response.
+    Client name **must be** same  as retrieved from database.
     '''
 
     user_query = query.replace('?',' ')


### PR DESCRIPTION
Bug 5602:Chatbot cannot distinguish between "this client" and a client mentioned by name


**Before Fix:** (AI is confused b/w this and client name)
![image](https://github.com/user-attachments/assets/7abb57c5-1a12-4029-a8ca-4d5021cd40b0)

**After Fix:** (AI is able to identify this and client name as same now)
have made the changes below is the screenshot attached
![image](https://github.com/user-attachments/assets/e536551c-43f2-49f2-a4d7-b97fb373b0ea)
