### PR TITLE
fix: Fixed bug 14071 to handle null object error in history generate method

### DIFF
--- a/ClientAdvisor/App/frontend/src/pages/chat/Chat.tsx
+++ b/ClientAdvisor/App/frontend/src/pages/chat/Chat.tsx
@@ -353,11 +353,30 @@ const Chat = (props: any) => {
       }
       if (response?.body) {
         const reader = response.body.getReader()
-
+        let firstRead = true
         let runningText = ''
         while (true) {
           setProcessMessages(messageStatus.Processing)
           const { done, value } = await reader.read()
+
+          // Handle Null Object (Undefined) response from History Generate Method
+          if (firstRead && done && value === undefined) {
+            let assistantMessage: ChatMessage = {
+              id: uuid(),
+              role: ASSISTANT,
+              content: 'There was an issue retrieving data. Please try again. If the problem persists, please contact the site administrator.',
+              date: new Date().toISOString()
+            };
+    
+            processResultMessage(assistantMessage, userMessage, conversationId);
+    
+            result.history_metadata = {
+              conversation_id: uuid(),
+              title: question,
+              date: assistantMessage.date
+            };
+          }
+          firstRead = false;
           if (done) break
 
           var text = new TextDecoder('utf-8').decode(value)


### PR DESCRIPTION

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This pull request includes a significant change to the `ClientAdvisor/App/frontend/src/pages/chat/Chat.tsx` file. The change primarily addresses the handling of null object responses from the History Generate Method to improve error handling and user experience.

Error handling improvement:

* Added a check for the first read operation to handle cases where the response is `undefined`. If this condition is met, a default error message is created and processed to inform the user about the issue, and metadata for the conversation history is generated.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here.. -->