### PR TITLE
fix: Client Advisor- After hovering over the chat history, no tooltip is displayed

### DIFF
--- a/ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.test.tsx
+++ b/ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.test.tsx
@@ -38,8 +38,8 @@ describe('ChatHistoryListItemCell', () => {
   test('renders the chat history item', () => {
     renderWithContext(<ChatHistoryListItemCell item={conversation} onSelect={mockOnSelect} />, mockAppState)
 
-    const titleElement = screen.getByText(/Test Chat/i)
-    expect(titleElement).toBeInTheDocument()
+    const titleElement = screen.getAllByText(/Test Chat/i)
+    expect(titleElement.length).toBeGreaterThan(1)
   })
 
   test('truncates long title', () => {
@@ -50,7 +50,7 @@ describe('ChatHistoryListItemCell', () => {
 
     renderWithContext(<ChatHistoryListItemCell item={longTitleConversation} onSelect={mockOnSelect} />, mockAppState)
 
-    const truncatedTitle = screen.getByText(/A very long title that shoul .../i)
+    const truncatedTitle = screen.getByText(/A very long title that s .../i)
     expect(truncatedTitle).toBeInTheDocument()
   })
 

--- a/ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.tsx
+++ b/ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.tsx
@@ -7,6 +7,7 @@ import {
   DialogType,
   IconButton,
   ITextField,
+  ITooltipHostStyles,
   List,
   PrimaryButton,
   Separator,
@@ -14,7 +15,9 @@ import {
   SpinnerSize,
   Stack,
   Text,
-  TextField
+  TextField,
+  TooltipHost,
+  DirectionalHint,
 } from '@fluentui/react'
 import { useBoolean } from '@fluentui/react-hooks'
 
@@ -107,7 +110,7 @@ export const ChatHistoryListItemCell: React.FC<ChatHistoryListItemCellProps> = (
     appStateContext?.dispatch({ type: 'UPDATE_CURRENT_CHAT', payload: item })
   }
 
-  const truncatedTitle = item?.title?.length > 28 ? `${item.title.substring(0, 28)} ...` : item.title
+  const truncatedTitle = item?.title?.length > 24 ? `${item.title.substring(0, 24)} ...` : item.title
 
   const handleSaveEdit = async (e: any) => {
     e.preventDefault()
@@ -236,8 +239,15 @@ export const ChatHistoryListItemCell: React.FC<ChatHistoryListItemCellProps> = (
         </>
       ) : (
         <>
-          <Stack horizontal verticalAlign={'center'} style={{ width: '100%' }}>
-            <div className={styles.chatTitle}>{truncatedTitle}</div>
+          <Stack horizontal verticalAlign={'center'} style={{ width: '100%' }}>            
+            <Stack.Item grow>
+              <TooltipHost
+                content={item.title}
+                directionalHint={DirectionalHint.bottomCenter}
+              >
+                <div className={styles.chatTitle}>{truncatedTitle}</div>
+              </TooltipHost>
+            </Stack.Item>
             {(isSelected || isHovered) && (
               <Stack horizontal horizontalAlign="end">
                 <IconButton


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request includes several changes to the `ChatHistoryListItemCell` component and its tests to improve the user interface and testing accuracy. The most important changes include updating the test cases to check for multiple elements, modifying the title truncation logic, and adding a tooltip for better user experience.

### Improvements to Testing:

* [`ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.test.tsx`](diffhunk://#diff-7cde97d686efa7a853f4865b347a15f3a825ce8e06fad55fce3f2a1aeb03587cL41-R42): Updated the test case to check for multiple elements with the same text using `getAllByText` instead of `getByText`.
* [`ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.test.tsx`](diffhunk://#diff-7cde97d686efa7a853f4865b347a15f3a825ce8e06fad55fce3f2a1aeb03587cL53-R53): Modified the expected truncated title text in the test case to match the new truncation logic.

### User Interface Enhancements:

* [`ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.tsx`](diffhunk://#diff-59db229b3b24b538ded61b5df5a1b57987ef7c509b110fa29873f75fd3dadf60R10-R20): Added `TooltipHost` and `DirectionalHint` from `@fluentui/react` to provide a tooltip for the chat title, enhancing the user experience. [[1]](diffhunk://#diff-59db229b3b24b538ded61b5df5a1b57987ef7c509b110fa29873f75fd3dadf60R10-R20) [[2]](diffhunk://#diff-59db229b3b24b538ded61b5df5a1b57987ef7c509b110fa29873f75fd3dadf60R243-R250)
* [`ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.tsx`](diffhunk://#diff-59db229b3b24b538ded61b5df5a1b57987ef7c509b110fa29873f75fd3dadf60L110-R113): Changed the title truncation logic to truncate titles longer than 24 characters instead of 28 characters for better display consistency.
### Dependency Updates:
This pull request includes several updates to the `ChatHistoryListItemCell` component and its corresponding tests to enhance functionality and improve user experience. The changes include updating the test cases, modifying the title truncation logic, and adding a tooltip for better accessibility.

Key changes include:

### Test Updates:
* Modified the test to check for multiple instances of the title "Test Chat" instead of just one. (`ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.test.tsx`)
* Updated the test to check for a truncated title with a shorter ellipsis. (`ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.test.tsx`)

### Component Enhancements:
* Imported `TooltipHost` and `DirectionalHint` from `@fluentui/react` to add tooltip functionality. (`ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.tsx`)
* Adjusted the title truncation logic to truncate titles longer than 24 characters instead of 28. (`ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.tsx`)
* Added a `TooltipHost` to display the full chat title when hovered over, improving accessibility for long titles. (`ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.tsx`)

### Improvements to `ChatHistoryListItemCell` component:

* Modified the title truncation logic to truncate titles longer than 24 characters instead of 28 characters (`ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.tsx`).
* Added `TooltipHost` to display full titles on hover, enhancing user experience for long titles (`ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.tsx`).
* Updated imports to include `TooltipHost` and `DirectionalHint` from `@fluentui/react` (`ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.tsx`).

### Updates to test cases:

* Changed the test to check for multiple instances of the title text instead of a single instance (`ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.test.tsx`).
* Updated the test to reflect the new truncation logic for long titles (`ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.test.tsx`).
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here.. -->
This pull request includes changes to the `ChatHistoryListItemCell` component and its associated tests in the `ClientAdvisor/App/frontend/src/components/ChatHistory` directory. The changes focus on modifying the title truncation logic, updating test cases, and adding a tooltip for better user experience.

### Changes to `ChatHistoryListItemCell` component:

* [`ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.tsx`](diffhunk://#diff-59db229b3b24b538ded61b5df5a1b57987ef7c509b110fa29873f75fd3dadf60L110-R113): Modified the title truncation logic to shorten the title length from 28 to 24 characters before truncating.
* [`ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.tsx`](diffhunk://#diff-59db229b3b24b538ded61b5df5a1b57987ef7c509b110fa29873f75fd3dadf60R243-R250): Added a `TooltipHost` component to display the full title when hovering over the truncated title.
* [`ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.tsx`](diffhunk://#diff-59db229b3b24b538ded61b5df5a1b57987ef7c509b110fa29873f75fd3dadf60R10-R20): Imported necessary components for the tooltip functionality, including `TooltipHost` and `DirectionalHint`.

### Changes to `ChatHistoryListItemCell` tests:

* [`ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.test.tsx`](diffhunk://#diff-7cde97d686efa7a853f4865b347a15f3a825ce8e06fad55fce3f2a1aeb03587cL41-R42): Updated the test for rendering the chat history item to check for multiple instances of the title text.
* [`ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.test.tsx`](diffhunk://#diff-7cde97d686efa7a853f4865b347a15f3a825ce8e06fad55fce3f2a1aeb03587cL53-R53): Updated the test for truncating long titles to match the new truncation logic.
This pull request includes changes to the `ChatHistoryListItemCell` component and its associated tests to improve the handling and display of chat history items. The most important changes include updating the test cases to handle multiple title elements, modifying the title truncation logic, and adding a tooltip for truncated titles.

Improvements to test cases:

* [`ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.test.tsx`](diffhunk://#diff-7cde97d686efa7a853f4865b347a15f3a825ce8e06fad55fce3f2a1aeb03587cL41-R42): Updated the test case to check for multiple instances of the chat title element instead of just one.
* [`ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.test.tsx`](diffhunk://#diff-7cde97d686efa7a853f4865b347a15f3a825ce8e06fad55fce3f2a1aeb03587cL53-R53): Modified the expected truncated title in the test case to match the new truncation logic.

Enhancements to the `ChatHistoryListItemCell` component:

* [`ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.tsx`](diffhunk://#diff-59db229b3b24b538ded61b5df5a1b57987ef7c509b110fa29873f75fd3dadf60R10-R20): Added `TooltipHost` and `DirectionalHint` imports for tooltip functionality.
* [`ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.tsx`](diffhunk://#diff-59db229b3b24b538ded61b5df5a1b57987ef7c509b110fa29873f75fd3dadf60L110-R113): Changed the title truncation length from 28 to 24 characters.
* [`ClientAdvisor/App/frontend/src/components/ChatHistory/ChatHistoryListItemCell.tsx`](diffhunk://#diff-59db229b3b24b538ded61b5df5a1b57987ef7c509b110fa29873f75fd3dadf60R243-R250): Added a tooltip to display the full chat title when it is truncated.