### PR TITLE
fix: Inject dynamic client name into Azure OpenAI host instructions

### DIFF
--- a/src/AzureFunction/function_app.py
+++ b/src/AzureFunction/function_app.py
@@ -3,6 +3,7 @@ import openai
 from azurefunctions.extensions.http.fastapi import Request, StreamingResponse
 import os
 from typing import Annotated
+from dotenv import load_dotenv
 
 from semantic_kernel.agents.open_ai import AzureAssistantAgent
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
@@ -18,7 +19,7 @@ import logging
 # Azure Function App setup
 # --------------------------
 app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
-
+load_dotenv()
 # Retrieve required environment variables
 endpoint = os.environ.get("AZURE_OPEN_AI_ENDPOINT")
 api_key = os.environ.get("AZURE_OPEN_AI_API_KEY")
@@ -339,7 +340,7 @@ async def stream_openai_text(req: Request) -> StreamingResponse:
             "If the user references a name that clearly differs from '{SelectedClientName}', respond only with: 'Please only ask questions about the selected client or select another client.' Otherwise, provide thorough answers for every question using only data from SQL or call transcripts."
             "If no data is found, respond with 'No data found for that client.' Remove any client identifiers from the final response."
         )
-
+    HOST_INSTRUCTIONS = HOST_INSTRUCTIONS.replace("{SelectedClientName}", selected_client_name)
     #Create the agent using the Semantic Kernel Assistant Agent
     kernel = Kernel()
     kernel.add_plugin(ChatWithDataPlugin(), plugin_name="ChatWithData")

--- a/src/AzureFunction/function_app.py
+++ b/src/AzureFunction/function_app.py
@@ -3,7 +3,6 @@ import openai
 from azurefunctions.extensions.http.fastapi import Request, StreamingResponse
 import os
 from typing import Annotated
-from dotenv import load_dotenv
 
 from semantic_kernel.agents.open_ai import AzureAssistantAgent
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
@@ -19,7 +18,7 @@ import logging
 # Azure Function App setup
 # --------------------------
 app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
-load_dotenv()
+
 # Retrieve required environment variables
 endpoint = os.environ.get("AZURE_OPEN_AI_ENDPOINT")
 api_key = os.environ.get("AZURE_OPEN_AI_API_KEY")


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This change dynamically replaces the placeholder `{SelectedClientName}` in `HOST_INSTRUCTIONS` with the actual selected client's name. 
This ensures all prompts and generated responses from Azure OpenAI are correctly contextualized, consistent, and specifically tailored to the currently selected client.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here.. -->