### PR TITLE
fix: pip package issue

### DIFF
--- a/ClientAdvisor/Deployment/scripts/fabric_scripts/requirements.txt
+++ b/ClientAdvisor/Deployment/scripts/fabric_scripts/requirements.txt
@@ -2,3 +2,4 @@ msal==1.31.1
 azure-identity
 pandas
 azure-storage-file-datalake
+packaging

--- a/ClientAdvisor/Deployment/scripts/fabric_scripts/run_fabric_items_scripts.sh
+++ b/ClientAdvisor/Deployment/scripts/fabric_scripts/run_fabric_items_scripts.sh
@@ -45,6 +45,6 @@ sed -i "s/workspaceId_to-be-replaced/${fabricWorkspaceId}/g" "create_fabric_item
 
 sed -i "s/kv_to-be-replaced/${keyvaultName}/g" "notebooks/01_process_data.ipynb"
 
-pip install -r requirements.txt --quiet
+pip install -r requirements.txt --user --quiet
 
 python create_fabric_items.py


### PR DESCRIPTION
## Purpose
This pull request includes updates to the `requirements.txt` file and a script used for deployment. The changes primarily focus on adding a new package dependency and modifying the installation command for Python packages.

Dependency updates:

* [`ClientAdvisor/Deployment/scripts/fabric_scripts/requirements.txt`](diffhunk://#diff-78c9a13865a79613ee2817e5ca2748360d40c2a4eb869841ac6a53d814d2724fR5): Added the `packaging` library to the list of required packages.

Script improvements:

* [`ClientAdvisor/Deployment/scripts/fabric_scripts/run_fabric_items_scripts.sh`](diffhunk://#diff-005e83a3715c4b2f87634aecef960d4f2e3da09714204fc395f775144e2443c4L48-R48): Modified the `pip install` command to include the `--user` flag, ensuring that packages are installed in the user’s site-packages directory.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No


## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.