### PR TITLE
feat: EXP environment changes for Log Analytics workspace

### DIFF
--- a/docs/CustomizingAzdParameters.md
+++ b/docs/CustomizingAzdParameters.md
@@ -41,3 +41,8 @@ Change the Embedding Deployment Capacity (choose a number based on available emb
 ```shell
 azd env set AZURE_ENV_EMBEDDING_MODEL_CAPACITY 80
 ```
+
+Set the Log Analytics Workspace Id if you need to reuse the existing workspace which is already existing
+```shell
+azd env set AZURE_ENV_LOG_ANALYTICS_WORKSPACE_ID '<Existing Log Analytics Workspace Id>'
+```

--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -114,6 +114,8 @@ When you start the deployment, most parameters will have **default values**, but
 | **GPT Model Deployment Capacity** | Configure capacity for **GPT models**. | 30k |
 | **Embedding Model** | OpenAI embedding model |  text-embedding-ada-002 |
 | **Embedding Model Capacity** | Set the capacity for **embedding models**. |  80k |
+| **Existing Log analytics workspace** | To reuse the existing Log analytics workspace Id. |  |
+
 
 </details>
 

--- a/infra/deploy_ai_foundry.bicep
+++ b/infra/deploy_ai_foundry.bicep
@@ -9,6 +9,7 @@ param gptDeploymentCapacity int
 param embeddingModel string
 param embeddingDeploymentCapacity int
 param managedIdentityObjectId string
+param existingLogAnalyticsWorkspaceId string = ''
 
 // Load the abbrevations file required to name the azure resources.
 var abbrs = loadJsonContent('./abbreviations.json')
@@ -54,7 +55,16 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
   name: keyVaultName
 }
 
-resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+var useExisting = !empty(existingLogAnalyticsWorkspaceId)
+var existingLawResourceGroup = useExisting ? split(existingLogAnalyticsWorkspaceId, '/')[4] : ''
+var existingLawName = useExisting ? split(existingLogAnalyticsWorkspaceId, '/')[8] : ''
+
+resource existingLogAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = if (useExisting) {
+  name: existingLawName
+  scope: resourceGroup(existingLawResourceGroup)
+}
+
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = if (!useExisting) {
   name: workspaceName
   location: location
   tags: {}
@@ -93,7 +103,7 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
     Application_Type: 'web'
     publicNetworkAccessForIngestion: 'Enabled'
     publicNetworkAccessForQuery: 'Enabled'
-    WorkspaceResourceId: logAnalytics.id
+    WorkspaceResourceId: useExisting ? existingLogAnalyticsWorkspace.id : logAnalytics.id
   }
 }
 
@@ -490,7 +500,10 @@ output aiSearchService string = aiSearch.name
 output aiProjectName string = aiHubProject.name
 
 output applicationInsightsId string = applicationInsights.id
-output logAnalyticsWorkspaceResourceName string = logAnalytics.name
+output logAnalyticsWorkspaceResourceName string = useExisting ? existingLogAnalyticsWorkspace.name : logAnalytics.name
+output logAnalyticsWorkspaceResourceGroup string = useExisting ? existingLawResourceGroup : resourceGroup().name
+
+
 output storageAccountName string = storageNameCleaned
 output applicationInsightsConnectionString string = applicationInsights.properties.ConnectionString
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -6,6 +6,9 @@ targetScope = 'resourceGroup'
 @description('A unique prefix for all resources in this deployment. This should be 3-20 characters long:')
 param environmentName string
 
+@description('Optional: Existing Log Analytics Workspace Resource ID')
+param existingLogAnalyticsWorkspaceId string = ''
+
 @description('CosmosDB Location')
 param cosmosLocation string
 
@@ -140,6 +143,7 @@ module aifoundry 'deploy_ai_foundry.bicep' = {
     embeddingModel: embeddingModel
     embeddingDeploymentCapacity: embeddingDeploymentCapacity
     managedIdentityObjectId:managedIdentityModule.outputs.managedIdentityOutput.objectId
+    existingLogAnalyticsWorkspaceId: existingLogAnalyticsWorkspaceId
   }
   scope: resourceGroup(resourceGroup().name)
 }

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -9,3 +9,4 @@ param gptDeploymentCapacity = int(readEnvironmentVariable('AZURE_ENV_MODEL_CAPAC
 param embeddingDeploymentCapacity = int(readEnvironmentVariable('AZURE_ENV_EMBEDDING_MODEL_CAPACITY', '80'))
 param AzureOpenAILocation = readEnvironmentVariable('AZURE_ENV_OPENAI_LOCATION', 'eastus2')
 param AZURE_LOCATION = readEnvironmentVariable('AZURE_LOCATION', '')
+param existingLogAnalyticsWorkspaceId = readEnvironmentVariable('AZURE_ENV_LOG_ANALYTICS_WORKSPACE_ID', '')


### PR DESCRIPTION
## Purpose
This pull request introduces support for reusing an existing Log Analytics Workspace during deployment. The changes span documentation updates, infrastructure configuration adjustments, and parameter additions to enable this functionality.

### Documentation Updates:
* [`docs/CustomizingAzdParameters.md`](diffhunk://#diff-6eec6ba43f4d3beb5835ad60e22b6974f1224c7b5ff024f690cd9549e8b4aec7R44-R48): Added instructions for setting the `AZURE_ENV_LOG_ANALYTICS_WORKSPACE_ID` environment variable to reuse an existing Log Analytics Workspace.
* [`docs/DeploymentGuide.md`](diffhunk://#diff-5a9feaaa3fe70489e88e08725db341b9dafb6a4185d382bba81c4093aaaded7cR117-R118): Updated the deployment guide to include a new parameter for specifying an existing Log Analytics Workspace ID.

### Infrastructure Configuration Enhancements:
* [`infra/deploy_ai_foundry.bicep`](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R12): Introduced the `existingLogAnalyticsWorkspaceId` parameter and logic for conditionally using an existing Log Analytics Workspace. Updated resource definitions to support conditional creation or reuse. [[1]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R12) [[2]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626L57-R67) [[3]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626L96-R106) [[4]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626L493-R506)

### Parameter Additions:
* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R9-R11): Added the `existingLogAnalyticsWorkspaceId` parameter to the main deployment module, allowing it to be passed to the AI Foundry deployment module. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R9-R11) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R146)
* [`infra/main.bicepparam`](diffhunk://#diff-c274a6091f4ca06948f0fe1ab8681ec4eb6b4e98c4be09717a2e3cacd1344727R12): Updated environment variable handling to include `AZURE_ENV_LOG_ANALYTICS_WORKSPACE_ID`.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->


## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.