### PR TITLE
feat: EXP environment changes for Existing Fabric workspace

### DIFF
--- a/docs/FabricDeployment.md
+++ b/docs/FabricDeployment.md
@@ -1,5 +1,8 @@
 ## Fabric Deployment
 ## Step 1: Create Fabric workspace
+
+ℹ️ Note: If you already have an existing Microsoft Fabric Workspace, you can **skip this step** and proceed to Step 2. To retrieve an existing Workspace ID, check **Point 5 below**.
+
 1.  Navigate to ([Fabric Workspace](https://app.fabric.microsoft.com/))
 2.  Click on Workspaces from left Navigation
 3.  Click on + New Workspace
@@ -19,7 +22,7 @@
       - ```cd ./Build-your-own-copilot-Solution-Accelerator/infra/scripts/fabric_scripts```
       - ```sh ./run_fabric_items_scripts.sh keyvault_param workspaceid_param solutionprefix_param```  
          1. keyvault_param - the name of the keyvault that was created in Step 1
-         2. workspaceid_param - the workspaceid created in Step 2
+         2. workspaceid_param - Existing Workspaceid or workspaceid created in Step 2
          3. solutionprefix_param - prefix used to append to lakehouse upon creation
 4.  Get Fabric Lakehouse connection details:
 5.  Once deployment is complete, navigate to Fabric Workspace


### PR DESCRIPTION
## Purpose
This pull request updates the `docs/FabricDeployment.md` file to improve clarity and usability for users deploying Microsoft Fabric. The changes focus on providing additional guidance for users with existing workspaces and refining deployment instructions.

### Documentation improvements:

* Added a note in Step 1 to inform users with an existing Microsoft Fabric Workspace that they can skip the workspace creation step and retrieve their Workspace ID from Point 5. (`docs/FabricDeployment.md`, [docs/FabricDeployment.mdR3-R5](diffhunk://#diff-ec9f7472bd409561aeb81e8775f4899a289b0de3321391d5f1af99fb35d43773R3-R5))
* Updated Step 2 deployment instructions to clarify that the `workspaceid_param` can refer to an existing Workspace ID or one created in Step 2. (`docs/FabricDeployment.md`, [docs/FabricDeployment.mdL22-R25](diffhunk://#diff-ec9f7472bd409561aeb81e8775f4899a289b0de3321391d5f1af99fb35d43773L22-R25))

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.
