### PR TITLE
ci: enhance deployment failure email notifications in CAdeploy workflow

### DIFF
--- a/.github/workflows/CAdeploy.yml
+++ b/.github/workflows/CAdeploy.yml
@@ -519,9 +519,16 @@ jobs:
         if: failure() || needs.deploy.result == 'failure' || needs.e2e-test.result == 'failure'
         run: |
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      
+          # Construct the email body
+          EMAIL_BODY=$(cat <<EOF
+          {
+            "body": "<p>Dear Team,</p><p>We would like to inform you that the Build-your-own-copilot-Solution-Accelerator(Client Advisior) Automation process has encountered an issue and has failed to complete successfully.</p><p><strong>Build URL:</strong> ${RUN_URL}<br> ${OUTPUT}</p><p>Please investigate the matter at your earliest convenience.</p><p>Best regards,<br>Your Automation Team</p>"
+          }
+          EOF
+          )
+      
+          # Send the notification
           curl -X POST "${{ secrets.LOGIC_APP_URL }}" \
             -H "Content-Type: application/json" \
-            -d '{
-              "subject": "CA Deployment Failed",
-              "body": "<p>The CA Deployment pipeline failed.</p><p><a href=\"'${RUN_URL}'\">View Run</a></p>"
-            }'
+            -d "$EMAIL_BODY" || echo "Failed to send notification"


### PR DESCRIPTION
## Purpose
This pull request updates the `.github/workflows/CAdeploy.yml` file to enhance the notification process for deployment failures. The main improvement is the addition of a more detailed and structured email body for failure notifications.

### Notification process improvements:
* Enhanced the email body to include a detailed message with a personalized introduction, a description of the issue, the build URL, and a request for investigation. This replaces the previous minimalistic message.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.-NA

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.-NA

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here.. -->