### PR TITLE
chore: directory update in dependabot template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,7 +31,7 @@ updates:
           
   # 3. Python dependencies – Fabric Scripts
   - package-ecosystem: "pip"
-    directory: "/src/infra/scripts/fabric_scripts"
+    directory: "/infra/scripts/fabric_scripts"
     schedule:
       interval: "monthly"
     commit-message:
@@ -45,7 +45,7 @@ updates:
 
   # 4. Python dependencies – Index Scripts
   - package-ecosystem: "pip"
-    directory: "/src/infra/scripts/index_scripts"
+    directory: "/infra/scripts/index_scripts"
     schedule:
       interval: "monthly"
     commit-message:


### PR DESCRIPTION
## Purpose

This pull request updates the configuration for Dependabot to reflect new locations for Python script directories. The changes ensure that dependency updates are tracked in the correct locations after a directory restructuring.

Configuration updates:

* Updated the `directory` path for Fabric Scripts from `/src/infra/scripts/fabric_scripts` to `/infra/scripts/fabric_scripts` in `.github/dependabot.yml`.
* Updated the `directory` path for Index Scripts from `/src/infra/scripts/index_scripts` to `/infra/scripts/index_scripts` in `.github/dependabot.yml`.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->
