### PR TITLE
chore: down merging main into dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,7 +31,7 @@ updates:
           
   # 3. Python dependencies – Fabric Scripts
   - package-ecosystem: "pip"
-    directory: "/src/infra/scripts/fabric_scripts"
+    directory: "/infra/scripts/fabric_scripts"
     schedule:
       interval: "monthly"
     commit-message:
@@ -45,7 +45,7 @@ updates:
 
   # 4. Python dependencies – Index Scripts
   - package-ecosystem: "pip"
-    directory: "/src/infra/scripts/index_scripts"
+    directory: "/infra/scripts/index_scripts"
     schedule:
       interval: "monthly"
     commit-message:

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -74,8 +74,7 @@ param aiDeploymentsLocation string
 param AZURE_LOCATION string = ''
 var solutionLocation = empty(AZURE_LOCATION) ? resourceGroup().location : AZURE_LOCATION
 
-var uniqueId = toLower(uniqueString(environmentName, subscription().id, solutionLocation))
-
+var uniqueId = toLower(uniqueString(environmentName, subscription().id, solutionLocation, resourceGroup().name))
 var solutionPrefix = 'ca${padLeft(take(uniqueId, 12), 12, '0')}'
 
 // Load the abbrevations file required to name the azure resources.


### PR DESCRIPTION
## Purpose

This pull request updates the configuration for Dependabot to reflect recent changes in the project directory structure. Specifically, it corrects the paths for Python dependencies managed in the infrastructure scripts, ensuring that Dependabot monitors the correct locations for updates.

Configuration updates for directory structure:

* Updated the `directory` paths in `.github/dependabot.yml` for Fabric Scripts and Index Scripts from `/src/infra/scripts/...` to `/infra/scripts/...` to match the current project layout. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L34-R34) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L48-R48)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

