### PR TITLE
feat: Add required environment variables for local debugging in .env generated by azd up

### DIFF
--- a/.github/workflows/CAdeploy.yml
+++ b/.github/workflows/CAdeploy.yml
@@ -172,8 +172,8 @@ jobs:
           echo "STORAGE_CONTAINER=$STORAGE_CONTAINER" >> $GITHUB_ENV
           export KEYVAULT_NAME=$(echo "$DEPLOY_OUTPUT" | jq -r '.keY_VAULT_NAME.value')
           echo "KEYVAULT_NAME=$KEYVAULT_NAME" >> $GITHUB_ENV
-          export SQL_SERVER=$(echo "$DEPLOY_OUTPUT" | jq -r '.sqldB_SERVER.value')
-          echo "SQL_SERVER=$SQL_SERVER" >> $GITHUB_ENV
+          export SQL_SERVER_NAME=$(echo "$DEPLOY_OUTPUT" | jq -r '.sqldB_SERVER_NAME.value')
+          echo "SQL_SERVER_NAME=$SQL_SERVER_NAME" >> $GITHUB_ENV
           export SQL_DATABASE=$(echo "$DEPLOY_OUTPUT" | jq -r '.sqldB_DATABASE.value')
           echo "SQL_DATABASE=$SQL_DATABASE" >> $GITHUB_ENV
           export CLIENT_ID=$(echo "$DEPLOY_OUTPUT" | jq -r '.managedidentitY_WEBAPP_CLIENTID.value')
@@ -220,7 +220,7 @@ jobs:
             "" \
             "${{ secrets.AZURE_CLIENT_ID }}" \
             "${{ env.RG_NAME }}" \
-            "${{ env.SQL_SERVER }}" \
+            "${{ env.SQL_SERVER_NAME }}" \
             "${{ env.AI_FOUNDARY_NAME }}" \
             "${{ env.SEARCH_SERVICE_NAME }}" \
             "${{ env.RESOURCE_GROUP_NAME_FOUNDRY }}"
@@ -232,7 +232,7 @@ jobs:
           ]'
 
           bash ./infra/scripts/add_user_scripts/create_sql_user_and_role.sh \
-            "${{ env.SQL_SERVER }}.database.windows.net" \
+            "${{ env.SQL_SERVER_NAME }}.database.windows.net" \
             "${{ env.SQL_DATABASE }}" \
             "$user_roles_json" \
             "${{ secrets.AZURE_CLIENT_ID }}"

--- a/docs/LocalSetupAndDeploy.md
+++ b/docs/LocalSetupAndDeploy.md
@@ -13,7 +13,10 @@ Navigate to the `App` folder located in the `src` directory of the repository us
 
 ### 2. Configure Environment Variables
 - Copy the `.env.sample` file to a new file named `.env`.
-- Update the `.env` file with the required values from your Azure resource group.
+- Update the `.env` file with the required values from your Azure resource group in Azure Portal App Service environment variables.
+- Alternatively, if resources were
+provisioned using `azd provision` or `azd up`, a `.env` file is automatically generated in the `.azure/<env-name>/.env`
+file. To get your `<env-name>` run `azd env list` to see which env is default.
 
 ### 3. Start the Application
 - Run `start.cmd` (Windows) or `start.sh` (Linux/Mac) to:

--- a/infra/deploy_ai_foundry.bicep
+++ b/infra/deploy_ai_foundry.bicep
@@ -385,6 +385,7 @@ output aiSearchService string = aiSearch.name
 output aiFoundryProjectName string = !empty(existingAIProjectName) ? existingAIProjectName : aiFoundryProject.name
 
 output applicationInsightsId string = applicationInsights.id
+output instrumentationKey string = applicationInsights.properties.InstrumentationKey
 output logAnalyticsWorkspaceResourceName string = useExisting ? existingLogAnalyticsWorkspace.name : logAnalytics.name
 output logAnalyticsWorkspaceResourceGroup string = useExisting ? existingLawResourceGroup : resourceGroup().name
 

--- a/infra/deploy_app_service.bicep
+++ b/infra/deploy_app_service.bicep
@@ -10,6 +10,7 @@ param HostingPlanSku string = 'B2'
 
 param HostingPlanName string
 param WebsiteName string
+param AppEnvironment string
 
 // @description('Name of Application Insights')
 // param ApplicationInsightsName string = '${ solutionName }-app-insights'
@@ -187,7 +188,7 @@ resource Website 'Microsoft.Web/sites@2020-06-01' = {
       appSettings: [
         {
           name: 'APP_ENV'
-          value: 'Prod'
+          value: AppEnvironment
         }
         {
           name: 'APPINSIGHTS_INSTRUMENTATIONKEY'

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -51,6 +51,7 @@ param embeddingDeploymentCapacity int = 80
 
 // @description('Fabric Workspace Id if you have one, else leave it empty. ')
 // param fabricWorkspaceId string
+@description('The Docker image tag to use for the application deployment.')
 param imageTag string = 'latest'
 
 //restricting to these regions because assistants api for gpt-4o-mini is available only in these regions
@@ -83,6 +84,34 @@ var abbrs = loadJsonContent('./abbreviations.json')
 //var resourceGroupLocation = resourceGroup().location
 //var solutionLocation = resourceGroupLocation
 // var baseUrl = 'https://raw.githubusercontent.com/microsoft/Build-your-own-copilot-Solution-Accelerator/main/'
+
+var hostingPlanName = '${abbrs.compute.appServicePlan}${solutionPrefix}'
+var websiteName = '${abbrs.compute.webApp}${solutionPrefix}'
+var appEnvironment = 'Prod'
+var azureSearchIndex = 'transcripts_index'
+var azureSearchUseSemanticSearch = 'True'
+var azureSearchSemanticSearchConfig = 'my-semantic-config'
+var azureSearchTopK = '5'
+var azureSearchContentColumns = 'content'
+var azureSearchFilenameColumn = 'chunk_id'
+var azureSearchTitleColumn = 'client_id'
+var azureSearchUrlColumn = 'sourceurl'
+var azureOpenAITemperature = '0'
+var azureOpenAITopP = '1'
+var azureOpenAIMaxTokens = '1000'
+var azureOpenAIStopSequence = '\n'
+var azureOpenAISystemMessage = '''You are a helpful Wealth Advisor assistant'''
+var azureOpenAIStream = 'True'
+var azureSearchQueryType = 'simple'
+var azureSearchVectorFields = 'contentVector'
+var azureSearchPermittedGroupsField = ''
+var azureSearchStrictness = '3'
+var azureSearchEnableInDomain = 'False' // Set to 'True' if you want to enable in-domain search
+var azureCosmosDbEnableFeedback = 'True'
+var useInternalStream = 'True'
+var useAIProjectClientFlag = 'False'
+var sqlServerFqdn = '${sqlDBModule.outputs.sqlServerName}.database.windows.net'
+
 
 var functionAppSqlPrompt = '''Generate a valid T-SQL query to find {query} for tables and columns provided below:
    1. Table: Clients
@@ -219,40 +248,41 @@ module appserviceModule 'deploy_app_service.bicep' = {
   name: 'deploy_app_service'
   params: {
     solutionLocation: solutionLocation
-    HostingPlanName: '${abbrs.compute.appServicePlan}${solutionPrefix}'
-    WebsiteName: '${abbrs.compute.webApp}${solutionPrefix}'
+    HostingPlanName: hostingPlanName
+    WebsiteName: websiteName
+    AppEnvironment: appEnvironment
     AzureSearchService: aifoundry.outputs.aiSearchService
-    AzureSearchIndex: 'transcripts_index'
-    AzureSearchUseSemanticSearch: 'True'
-    AzureSearchSemanticSearchConfig: 'my-semantic-config'
-    AzureSearchTopK: '5'
-    AzureSearchContentColumns: 'content'
-    AzureSearchFilenameColumn: 'chunk_id'
-    AzureSearchTitleColumn: 'client_id'
-    AzureSearchUrlColumn: 'sourceurl'
+    AzureSearchIndex: azureSearchIndex
+    AzureSearchUseSemanticSearch: azureSearchUseSemanticSearch
+    AzureSearchSemanticSearchConfig: azureSearchSemanticSearchConfig
+    AzureSearchTopK: azureSearchTopK
+    AzureSearchContentColumns: azureSearchContentColumns
+    AzureSearchFilenameColumn: azureSearchFilenameColumn
+    AzureSearchTitleColumn: azureSearchTitleColumn
+    AzureSearchUrlColumn: azureSearchUrlColumn
     AzureOpenAIResource: aifoundry.outputs.aiFoundryName
     AzureOpenAIEndpoint: aifoundry.outputs.aoaiEndpoint
     AzureOpenAIModel: gptModelName
-    AzureOpenAITemperature: '0'
-    AzureOpenAITopP: '1'
-    AzureOpenAIMaxTokens: '1000'
-    AzureOpenAIStopSequence: ''
-    AzureOpenAISystemMessage: '''You are a helpful Wealth Advisor assistant'''
+    AzureOpenAITemperature: azureOpenAITemperature
+    AzureOpenAITopP: azureOpenAITopP
+    AzureOpenAIMaxTokens: azureOpenAIMaxTokens
+    AzureOpenAIStopSequence: azureOpenAIStopSequence
+    AzureOpenAISystemMessage: azureOpenAISystemMessage
     AzureOpenAIApiVersion: azureOpenaiAPIVersion
-    AzureOpenAIStream: 'True'
-    AzureSearchQueryType: 'simple'
-    AzureSearchVectorFields: 'contentVector'
-    AzureSearchPermittedGroupsField: ''
-    AzureSearchStrictness: '3'
+    AzureOpenAIStream: azureOpenAIStream
+    AzureSearchQueryType: azureSearchQueryType
+    AzureSearchVectorFields: azureSearchVectorFields
+    AzureSearchPermittedGroupsField: azureSearchPermittedGroupsField
+    AzureSearchStrictness: azureSearchStrictness
     AzureOpenAIEmbeddingName: embeddingModel
     AzureOpenAIEmbeddingEndpoint: aifoundry.outputs.aoaiEndpoint
-    USE_INTERNAL_STREAM: 'True'
-    SQLDB_SERVER: '${sqlDBModule.outputs.sqlServerName}.database.windows.net'
+    USE_INTERNAL_STREAM: useInternalStream
+    SQLDB_SERVER: sqlServerFqdn
     SQLDB_DATABASE: sqlDBModule.outputs.sqlDbName
     AZURE_COSMOSDB_ACCOUNT: cosmosDBModule.outputs.cosmosAccountName
     AZURE_COSMOSDB_CONVERSATIONS_CONTAINER: cosmosDBModule.outputs.cosmosContainerName
     AZURE_COSMOSDB_DATABASE: cosmosDBModule.outputs.cosmosDatabaseName
-    AZURE_COSMOSDB_ENABLE_FEEDBACK: 'True'
+    AZURE_COSMOSDB_ENABLE_FEEDBACK: azureCosmosDbEnableFeedback
     //VITE_POWERBI_EMBED_URL: 'TBD'
     imageTag: imageTag
     userassignedIdentityClientId: managedIdentityModule.outputs.managedIdentityWebAppOutput.clientId
@@ -279,10 +309,55 @@ output KEY_VAULT_NAME string = keyvaultModule.outputs.keyvaultName
 output COSMOSDB_ACCOUNT_NAME string = cosmosDBModule.outputs.cosmosAccountName
 output RESOURCE_GROUP_NAME string = resourceGroup().name
 output RESOURCE_GROUP_NAME_FOUNDRY string = aifoundry.outputs.resourceGroupNameFoundry
-output SQLDB_SERVER string = sqlDBModule.outputs.sqlServerName
+output SQLDB_SERVER_NAME string = sqlDBModule.outputs.sqlServerName
 output SQLDB_DATABASE string = sqlDBModule.outputs.sqlDbName
 output MANAGEDIDENTITY_WEBAPP_NAME string = managedIdentityModule.outputs.managedIdentityWebAppOutput.name
 output MANAGEDIDENTITY_WEBAPP_CLIENTID string = managedIdentityModule.outputs.managedIdentityWebAppOutput.clientId
 output AI_FOUNDRY_NAME string = aifoundry.outputs.aiFoundryName
 output AI_SEARCH_SERVICE_NAME string = aifoundry.outputs.aiSearchService
 output WEB_APP_NAME string = appserviceModule.outputs.webAppName
+output APP_ENV string = appEnvironment
+output APPINSIGHTS_INSTRUMENTATIONKEY string = aifoundry.outputs.instrumentationKey
+output APPLICATIONINSIGHTS_CONNECTION_STRING string = aifoundry.outputs.applicationInsightsConnectionString
+output AZURE_AI_AGENT_API_VERSION string = azureOpenaiAPIVersion
+output AZURE_AI_AGENT_ENDPOINT string = aifoundry.outputs.aiFoundryProjectEndpoint
+output AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME string = gptModelName
+output AZURE_AI_SEARCH_ENDPOINT string = aifoundry.outputs.aiSearchTarget
+output AZURE_CALL_TRANSCRIPT_SYSTEM_PROMPT string = functionAppCallTranscriptSystemPrompt
+output AZURE_COSMOSDB_ACCOUNT string = cosmosDBModule.outputs.cosmosAccountName
+output AZURE_COSMOSDB_CONVERSATIONS_CONTAINER string = cosmosDBModule.outputs.cosmosContainerName
+output AZURE_COSMOSDB_DATABASE string = cosmosDBModule.outputs.cosmosDatabaseName
+output AZURE_COSMOSDB_ENABLE_FEEDBACK string = azureCosmosDbEnableFeedback
+output AZURE_OPENAI_EMBEDDING_ENDPOINT string = aifoundry.outputs.aoaiEndpoint
+output AZURE_OPENAI_EMBEDDING_NAME string = embeddingModel
+output AZURE_OPENAI_ENDPOINT string = aifoundry.outputs.aoaiEndpoint
+output AZURE_OPENAI_MAX_TOKENS string = azureOpenAIMaxTokens
+output AZURE_OPENAI_MODEL string = gptModelName
+output AZURE_OPENAI_PREVIEW_API_VERSION string = azureOpenaiAPIVersion
+output AZURE_OPENAI_RESOURCE string = aifoundry.outputs.aiFoundryName
+output AZURE_OPENAI_STOP_SEQUENCE string = azureOpenAIStopSequence
+output AZURE_OPENAI_STREAM string = azureOpenAIStream
+output AZURE_OPENAI_STREAM_TEXT_SYSTEM_PROMPT string = functionAppStreamTextSystemPrompt
+output AZURE_OPENAI_SYSTEM_MESSAGE string = azureOpenAISystemMessage
+output AZURE_OPENAI_TEMPERATURE string = azureOpenAITemperature
+output AZURE_OPENAI_TOP_P string = azureOpenAITopP
+output AZURE_SEARCH_CONNECTION_NAME string = aifoundry.outputs.aiSearchFoundryConnectionName
+output AZURE_SEARCH_CONTENT_COLUMNS string = azureSearchContentColumns
+output AZURE_SEARCH_ENABLE_IN_DOMAIN string = azureSearchEnableInDomain
+output AZURE_SEARCH_FILENAME_COLUMN string = azureSearchFilenameColumn
+output AZURE_SEARCH_INDEX string = azureSearchIndex
+output AZURE_SEARCH_PERMITTED_GROUPS_COLUMN string = azureSearchPermittedGroupsField
+output AZURE_SEARCH_QUERY_TYPE string = azureSearchQueryType
+output AZURE_SEARCH_SEMANTIC_SEARCH_CONFIG string = azureSearchSemanticSearchConfig
+output AZURE_SEARCH_SERVICE string = aifoundry.outputs.aiSearchService
+output AZURE_SEARCH_STRICTNESS string = azureSearchStrictness
+output AZURE_SEARCH_TITLE_COLUMN string = azureSearchTitleColumn
+output AZURE_SEARCH_TOP_K string = azureSearchTopK
+output AZURE_SEARCH_URL_COLUMN string = azureSearchUrlColumn
+output AZURE_SEARCH_USE_SEMANTIC_SEARCH string = azureSearchUseSemanticSearch
+output AZURE_SEARCH_VECTOR_COLUMNS string = azureSearchVectorFields
+output AZURE_SQL_SYSTEM_PROMPT string = functionAppSqlPrompt
+output SQLDB_SERVER string = sqlServerFqdn
+output SQLDB_USER_MID string = managedIdentityModule.outputs.managedIdentityWebAppOutput.clientId
+output USE_AI_PROJECT_CLIENT string = useAIProjectClientFlag
+output USE_INTERNAL_STREAM string = useInternalStream

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.36.177.2456",
-      "templateHash": "7434704573623874481"
+      "templateHash": "8388189115253050142"
     }
   },
   "parameters": {
@@ -94,7 +94,10 @@
     },
     "imageTag": {
       "type": "string",
-      "defaultValue": "latest"
+      "defaultValue": "latest",
+      "metadata": {
+        "description": "The Docker image tag to use for the application deployment."
+      }
     },
     "aiDeploymentsLocation": {
       "type": "string",
@@ -362,6 +365,31 @@
     "uniqueId": "[toLower(uniqueString(parameters('environmentName'), subscription().id, variables('solutionLocation'), resourceGroup().name))]",
     "solutionPrefix": "[format('ca{0}', padLeft(take(variables('uniqueId'), 12), 12, '0'))]",
     "abbrs": "[variables('$fxv#0')]",
+    "hostingPlanName": "[format('{0}{1}', variables('abbrs').compute.appServicePlan, variables('solutionPrefix'))]",
+    "websiteName": "[format('{0}{1}', variables('abbrs').compute.webApp, variables('solutionPrefix'))]",
+    "appEnvironment": "Prod",
+    "azureSearchIndex": "transcripts_index",
+    "azureSearchUseSemanticSearch": "True",
+    "azureSearchSemanticSearchConfig": "my-semantic-config",
+    "azureSearchTopK": "5",
+    "azureSearchContentColumns": "content",
+    "azureSearchFilenameColumn": "chunk_id",
+    "azureSearchTitleColumn": "client_id",
+    "azureSearchUrlColumn": "sourceurl",
+    "azureOpenAITemperature": "0",
+    "azureOpenAITopP": "1",
+    "azureOpenAIMaxTokens": "1000",
+    "azureOpenAIStopSequence": "\n",
+    "azureOpenAISystemMessage": "You are a helpful Wealth Advisor assistant",
+    "azureOpenAIStream": "True",
+    "azureSearchQueryType": "simple",
+    "azureSearchVectorFields": "contentVector",
+    "azureSearchPermittedGroupsField": "",
+    "azureSearchStrictness": "3",
+    "azureSearchEnableInDomain": "False",
+    "azureCosmosDbEnableFeedback": "True",
+    "useInternalStream": "True",
+    "useAIProjectClientFlag": "False",
     "functionAppSqlPrompt": "Generate a valid T-SQL query to find {query} for tables and columns provided below:\r\n   1. Table: Clients\r\n   Columns: ClientId, Client, Email, Occupation, MaritalStatus, Dependents\r\n   2. Table: InvestmentGoals\r\n   Columns: ClientId, InvestmentGoal\r\n   3. Table: Assets\r\n   Columns: ClientId, AssetDate, Investment, ROI, Revenue, AssetType\r\n   4. Table: ClientSummaries\r\n   Columns: ClientId, ClientSummary\r\n   5. Table: InvestmentGoalsDetails\r\n   Columns: ClientId, InvestmentGoal, TargetAmount, Contribution\r\n   6. Table: Retirement\r\n   Columns: ClientId, StatusDate, RetirementGoalProgress, EducationGoalProgress\r\n   7. Table: ClientMeetings\r\n   Columns: ClientId, ConversationId, Title, StartTime, EndTime, Advisor, ClientEmail\r\n   Always use the Investment column from the Assets table as the value.\r\n   Assets table has snapshots of values by date. Do not add numbers across different dates for total values.\r\n   Do not use client name in filters.\r\n   Do not include assets values unless asked for.\r\n   ALWAYS use ClientId = {clientid} in the query filter.\r\n   ALWAYS select Client Name (Column: Client) in the query.\r\n   Query filters are IMPORTANT. Add filters like AssetType, AssetDate, etc. if needed.\r\n   When answering scheduling or time-based meeting questions, always use the StartTime column from ClientMeetings table. Use correct logic to return the most recent past meeting (last/previous) or the nearest future meeting (next/upcoming), and ensure only StartTime column is used for meeting timing comparisons.\r\n   Only return the generated SQL query. Do not return anything else.",
     "functionAppCallTranscriptSystemPrompt": "You are an assistant who supports wealth advisors in preparing for client meetings. \r\n  You have access to the client’s past meeting call transcripts. \r\n  When answering questions, especially summary requests, provide a detailed and structured response that includes key topics, concerns, decisions, and trends. \r\n  If no data is available, state 'No relevant data found for previous meetings.",
     "functionAppStreamTextSystemPrompt": "The currently selected client's name is '{SelectedClientName}'. Treat any case-insensitive or partial mention as referring to this client.\r\n  If the user mentions no name, assume they are asking about '{SelectedClientName}'.\r\n  If the user references a name that clearly differs from '{SelectedClientName}' or comparing with other clients, respond only with: 'Please only ask questions about the selected client or select another client.' Otherwise, provide thorough answers for every question using only data from SQL or call transcripts.'\r\n  If no data is found, respond with 'No data found for that client.' Remove any client identifiers from the final response.\r\n  Always send clientId as '{client_id}'."
@@ -744,7 +772,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.36.177.2456",
-              "templateHash": "13609803072209612016"
+              "templateHash": "5605479917210969670"
             }
           },
           "parameters": {
@@ -1608,6 +1636,10 @@
               "type": "string",
               "value": "[resourceId('Microsoft.Insights/components', variables('applicationInsightsName'))]"
             },
+            "instrumentationKey": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Insights/components', variables('applicationInsightsName')), '2020-02-02').InstrumentationKey]"
+            },
             "logAnalyticsWorkspaceResourceName": {
               "type": "string",
               "value": "[if(variables('useExisting'), variables('existingLawName'), variables('workspaceName'))]"
@@ -2152,37 +2184,40 @@
             "value": "[variables('solutionLocation')]"
           },
           "HostingPlanName": {
-            "value": "[format('{0}{1}', variables('abbrs').compute.appServicePlan, variables('solutionPrefix'))]"
+            "value": "[variables('hostingPlanName')]"
           },
           "WebsiteName": {
-            "value": "[format('{0}{1}', variables('abbrs').compute.webApp, variables('solutionPrefix'))]"
+            "value": "[variables('websiteName')]"
+          },
+          "AppEnvironment": {
+            "value": "[variables('appEnvironment')]"
           },
           "AzureSearchService": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.aiSearchService.value]"
           },
           "AzureSearchIndex": {
-            "value": "transcripts_index"
+            "value": "[variables('azureSearchIndex')]"
           },
           "AzureSearchUseSemanticSearch": {
-            "value": "True"
+            "value": "[variables('azureSearchUseSemanticSearch')]"
           },
           "AzureSearchSemanticSearchConfig": {
-            "value": "my-semantic-config"
+            "value": "[variables('azureSearchSemanticSearchConfig')]"
           },
           "AzureSearchTopK": {
-            "value": "5"
+            "value": "[variables('azureSearchTopK')]"
           },
           "AzureSearchContentColumns": {
-            "value": "content"
+            "value": "[variables('azureSearchContentColumns')]"
           },
           "AzureSearchFilenameColumn": {
-            "value": "chunk_id"
+            "value": "[variables('azureSearchFilenameColumn')]"
           },
           "AzureSearchTitleColumn": {
-            "value": "client_id"
+            "value": "[variables('azureSearchTitleColumn')]"
           },
           "AzureSearchUrlColumn": {
-            "value": "sourceurl"
+            "value": "[variables('azureSearchUrlColumn')]"
           },
           "AzureOpenAIResource": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.aiFoundryName.value]"
@@ -2194,37 +2229,37 @@
             "value": "[parameters('gptModelName')]"
           },
           "AzureOpenAITemperature": {
-            "value": "0"
+            "value": "[variables('azureOpenAITemperature')]"
           },
           "AzureOpenAITopP": {
-            "value": "1"
+            "value": "[variables('azureOpenAITopP')]"
           },
           "AzureOpenAIMaxTokens": {
-            "value": "1000"
+            "value": "[variables('azureOpenAIMaxTokens')]"
           },
           "AzureOpenAIStopSequence": {
-            "value": ""
+            "value": "[variables('azureOpenAIStopSequence')]"
           },
           "AzureOpenAISystemMessage": {
-            "value": "You are a helpful Wealth Advisor assistant"
+            "value": "[variables('azureOpenAISystemMessage')]"
           },
           "AzureOpenAIApiVersion": {
             "value": "[parameters('azureOpenaiAPIVersion')]"
           },
           "AzureOpenAIStream": {
-            "value": "True"
+            "value": "[variables('azureOpenAIStream')]"
           },
           "AzureSearchQueryType": {
-            "value": "simple"
+            "value": "[variables('azureSearchQueryType')]"
           },
           "AzureSearchVectorFields": {
-            "value": "contentVector"
+            "value": "[variables('azureSearchVectorFields')]"
           },
           "AzureSearchPermittedGroupsField": {
-            "value": ""
+            "value": "[variables('azureSearchPermittedGroupsField')]"
           },
           "AzureSearchStrictness": {
-            "value": "3"
+            "value": "[variables('azureSearchStrictness')]"
           },
           "AzureOpenAIEmbeddingName": {
             "value": "[parameters('embeddingModel')]"
@@ -2233,7 +2268,7 @@
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.aoaiEndpoint.value]"
           },
           "USE_INTERNAL_STREAM": {
-            "value": "True"
+            "value": "[variables('useInternalStream')]"
           },
           "SQLDB_SERVER": {
             "value": "[format('{0}.database.windows.net', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_sql_db'), '2022-09-01').outputs.sqlServerName.value)]"
@@ -2251,7 +2286,7 @@
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_cosmos_db'), '2022-09-01').outputs.cosmosDatabaseName.value]"
           },
           "AZURE_COSMOSDB_ENABLE_FEEDBACK": {
-            "value": "True"
+            "value": "[variables('azureCosmosDbEnableFeedback')]"
           },
           "imageTag": {
             "value": "[parameters('imageTag')]"
@@ -2300,7 +2335,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.36.177.2456",
-              "templateHash": "14489288067602272519"
+              "templateHash": "17855260504239152628"
             }
           },
           "parameters": {
@@ -2336,6 +2371,9 @@
               "type": "string"
             },
             "WebsiteName": {
+              "type": "string"
+            },
+            "AppEnvironment": {
               "type": "string"
             },
             "AzureSearchService": {
@@ -2674,7 +2712,7 @@
                   "appSettings": [
                     {
                       "name": "APP_ENV",
-                      "value": "Prod"
+                      "value": "[parameters('AppEnvironment')]"
                     },
                     {
                       "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
@@ -3102,7 +3140,7 @@
       "type": "string",
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.resourceGroupNameFoundry.value]"
     },
-    "SQLDB_SERVER": {
+    "SQLDB_SERVER_NAME": {
       "type": "string",
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_sql_db'), '2022-09-01').outputs.sqlServerName.value]"
     },
@@ -3129,6 +3167,186 @@
     "WEB_APP_NAME": {
       "type": "string",
       "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_app_service'), '2022-09-01').outputs.webAppName.value]"
+    },
+    "APP_ENV": {
+      "type": "string",
+      "value": "[variables('appEnvironment')]"
+    },
+    "APPINSIGHTS_INSTRUMENTATIONKEY": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.instrumentationKey.value]"
+    },
+    "APPLICATIONINSIGHTS_CONNECTION_STRING": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.applicationInsightsConnectionString.value]"
+    },
+    "AZURE_AI_AGENT_API_VERSION": {
+      "type": "string",
+      "value": "[parameters('azureOpenaiAPIVersion')]"
+    },
+    "AZURE_AI_AGENT_ENDPOINT": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.aiFoundryProjectEndpoint.value]"
+    },
+    "AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME": {
+      "type": "string",
+      "value": "[parameters('gptModelName')]"
+    },
+    "AZURE_AI_SEARCH_ENDPOINT": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.aiSearchTarget.value]"
+    },
+    "AZURE_CALL_TRANSCRIPT_SYSTEM_PROMPT": {
+      "type": "string",
+      "value": "[variables('functionAppCallTranscriptSystemPrompt')]"
+    },
+    "AZURE_COSMOSDB_ACCOUNT": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_cosmos_db'), '2022-09-01').outputs.cosmosAccountName.value]"
+    },
+    "AZURE_COSMOSDB_CONVERSATIONS_CONTAINER": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_cosmos_db'), '2022-09-01').outputs.cosmosContainerName.value]"
+    },
+    "AZURE_COSMOSDB_DATABASE": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_cosmos_db'), '2022-09-01').outputs.cosmosDatabaseName.value]"
+    },
+    "AZURE_COSMOSDB_ENABLE_FEEDBACK": {
+      "type": "string",
+      "value": "[variables('azureCosmosDbEnableFeedback')]"
+    },
+    "AZURE_OPENAI_EMBEDDING_ENDPOINT": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.aoaiEndpoint.value]"
+    },
+    "AZURE_OPENAI_EMBEDDING_NAME": {
+      "type": "string",
+      "value": "[parameters('embeddingModel')]"
+    },
+    "AZURE_OPENAI_ENDPOINT": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.aoaiEndpoint.value]"
+    },
+    "AZURE_OPENAI_MAX_TOKENS": {
+      "type": "string",
+      "value": "[variables('azureOpenAIMaxTokens')]"
+    },
+    "AZURE_OPENAI_MODEL": {
+      "type": "string",
+      "value": "[parameters('gptModelName')]"
+    },
+    "AZURE_OPENAI_PREVIEW_API_VERSION": {
+      "type": "string",
+      "value": "[parameters('azureOpenaiAPIVersion')]"
+    },
+    "AZURE_OPENAI_RESOURCE": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.aiFoundryName.value]"
+    },
+    "AZURE_OPENAI_STOP_SEQUENCE": {
+      "type": "string",
+      "value": "[variables('azureOpenAIStopSequence')]"
+    },
+    "AZURE_OPENAI_STREAM": {
+      "type": "string",
+      "value": "[variables('azureOpenAIStream')]"
+    },
+    "AZURE_OPENAI_STREAM_TEXT_SYSTEM_PROMPT": {
+      "type": "string",
+      "value": "[variables('functionAppStreamTextSystemPrompt')]"
+    },
+    "AZURE_OPENAI_SYSTEM_MESSAGE": {
+      "type": "string",
+      "value": "[variables('azureOpenAISystemMessage')]"
+    },
+    "AZURE_OPENAI_TEMPERATURE": {
+      "type": "string",
+      "value": "[variables('azureOpenAITemperature')]"
+    },
+    "AZURE_OPENAI_TOP_P": {
+      "type": "string",
+      "value": "[variables('azureOpenAITopP')]"
+    },
+    "AZURE_SEARCH_CONNECTION_NAME": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.aiSearchFoundryConnectionName.value]"
+    },
+    "AZURE_SEARCH_CONTENT_COLUMNS": {
+      "type": "string",
+      "value": "[variables('azureSearchContentColumns')]"
+    },
+    "AZURE_SEARCH_ENABLE_IN_DOMAIN": {
+      "type": "string",
+      "value": "[variables('azureSearchEnableInDomain')]"
+    },
+    "AZURE_SEARCH_FILENAME_COLUMN": {
+      "type": "string",
+      "value": "[variables('azureSearchFilenameColumn')]"
+    },
+    "AZURE_SEARCH_INDEX": {
+      "type": "string",
+      "value": "[variables('azureSearchIndex')]"
+    },
+    "AZURE_SEARCH_PERMITTED_GROUPS_COLUMN": {
+      "type": "string",
+      "value": "[variables('azureSearchPermittedGroupsField')]"
+    },
+    "AZURE_SEARCH_QUERY_TYPE": {
+      "type": "string",
+      "value": "[variables('azureSearchQueryType')]"
+    },
+    "AZURE_SEARCH_SEMANTIC_SEARCH_CONFIG": {
+      "type": "string",
+      "value": "[variables('azureSearchSemanticSearchConfig')]"
+    },
+    "AZURE_SEARCH_SERVICE": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_ai_foundry'), '2022-09-01').outputs.aiSearchService.value]"
+    },
+    "AZURE_SEARCH_STRICTNESS": {
+      "type": "string",
+      "value": "[variables('azureSearchStrictness')]"
+    },
+    "AZURE_SEARCH_TITLE_COLUMN": {
+      "type": "string",
+      "value": "[variables('azureSearchTitleColumn')]"
+    },
+    "AZURE_SEARCH_TOP_K": {
+      "type": "string",
+      "value": "[variables('azureSearchTopK')]"
+    },
+    "AZURE_SEARCH_URL_COLUMN": {
+      "type": "string",
+      "value": "[variables('azureSearchUrlColumn')]"
+    },
+    "AZURE_SEARCH_USE_SEMANTIC_SEARCH": {
+      "type": "string",
+      "value": "[variables('azureSearchUseSemanticSearch')]"
+    },
+    "AZURE_SEARCH_VECTOR_COLUMNS": {
+      "type": "string",
+      "value": "[variables('azureSearchVectorFields')]"
+    },
+    "AZURE_SQL_SYSTEM_PROMPT": {
+      "type": "string",
+      "value": "[variables('functionAppSqlPrompt')]"
+    },
+    "SQLDB_SERVER": {
+      "type": "string",
+      "value": "[format('{0}.database.windows.net', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_sql_db'), '2022-09-01').outputs.sqlServerName.value)]"
+    },
+    "SQLDB_USER_MID": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_managed_identity'), '2022-09-01').outputs.managedIdentityWebAppOutput.value.clientId]"
+    },
+    "USE_AI_PROJECT_CLIENT": {
+      "type": "string",
+      "value": "[variables('useAIProjectClientFlag')]"
+    },
+    "USE_INTERNAL_STREAM": {
+      "type": "string",
+      "value": "[variables('useInternalStream')]"
     }
   }
 }

--- a/infra/scripts/process_sample_data.sh
+++ b/infra/scripts/process_sample_data.sh
@@ -40,7 +40,7 @@ if [ -z "$keyvaultName" ]; then
 fi
 
 if [ -z "$sqlServerName" ]; then
-    sqlServerName=$(azd env get-value SQLDB_SERVER)
+    sqlServerName=$(azd env get-value SQLDB_SERVER_NAME)
 fi
 
 if [ -z "$SqlDatabaseName" ]; then


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request introduces several improvements and refactors to the infrastructure deployment scripts and configuration files, focusing on parameterization, environment variable consistency, and output expansion. The main goals are to make deployments more flexible, maintainable, and to surface more useful output variables for downstream consumers. Below are the most important changes grouped by theme:

**Parameterization and Variable Refactoring:**

* Refactored hardcoded values in `infra/main.bicep` and `infra/main.json` to use variables for commonly reused configuration items (e.g., `hostingPlanName`, `websiteName`, `appEnvironment`, and various Azure Search/OpenAI parameters), improving maintainability and flexibility. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R88-R115) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L222-R285) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R368-R392) [[4]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2155-R2220)
* Added a new `imageTag` parameter with a description for Docker image deployments, making it clearer and easier to specify which image version to deploy. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R54) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L97-R100)

**Environment Variable and Output Consistency:**

* Standardized SQL server environment variable naming from `SQL_SERVER` to `SQL_SERVER_NAME` across the GitHub Actions workflow (`.github/workflows/CAdeploy.yml`) and corresponding references, ensuring consistency and reducing confusion. [[1]](diffhunk://#diff-67593888fa4a3b8c26f65fe9387615f60cda88c80b3eb1407e6330d5e8bb1468L175-R176) [[2]](diffhunk://#diff-67593888fa4a3b8c26f65fe9387615f60cda88c80b3eb1407e6330d5e8bb1468L223-R223) [[3]](diffhunk://#diff-67593888fa4a3b8c26f65fe9387615f60cda88c80b3eb1407e6330d5e8bb1468L235-R235) [[4]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L282-R363)
* Expanded outputs in `infra/main.bicep` to include a comprehensive set of environment variables and connection strings for downstream use, such as Application Insights keys, Cosmos DB info, AI endpoints, and more.

**Application Settings and Deployment Improvements:**

* Modified the `deploy_app_service.bicep` module to accept `AppEnvironment` as a parameter and use it for the `APP_ENV` application setting, allowing dynamic environment configuration (e.g., switching between 'Prod', 'Dev', etc.). [[1]](diffhunk://#diff-37c8b5694d17291d641a19fb8a562e30642066b4bf8b8657f2636f50567cf4ebR13) [[2]](diffhunk://#diff-37c8b5694d17291d641a19fb8a562e30642066b4bf8b8657f2636f50567cf4ebL190-R191) [[3]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L222-R285) [[4]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2155-R2220)
* Added output of the Application Insights instrumentation key in `deploy_ai_foundry.bicep` for easier integration with monitoring tools. [[1]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R388) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R1639-R1642)

**Local Debugging Improvements:**

- Ensured that all environment variables required for local debugging are automatically included in the .env file generated by azd up or azd provision. This streamlines the setup process for local development, allowing developers to start and debug the application locally with minimal manual configuration.

**Documentation Update:**

* Updated the local setup documentation to clarify how `.env` files are generated and where to find environment-specific files when using `azd provision` or `azd up`.

These changes collectively make the infrastructure codebase more modular, easier to configure for different environments, and improve the developer experience during both deployment and local setup.
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid:

- Ensure deployments (via both GitHub Actions and azd CLI) work as expected in all supported environments.
- Validate that the .env file generated by azd up contains all required variables for local debugging, and application starts up successfully with those.
- Confirm that documentation changes are clear for new and existing developers.
- Test that scripts and workflows referencing updated variable names (e.g., SQLDB_SERVER_NAME) work correctly.
- Review that outputs in Bicep and JSON templates are wired as expected and no breaking changes are introduced for existing deployments.

