### PR TITLE
chore: Add Bicep file to add CreatedBy tag

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -177,6 +177,7 @@ param tags resourceInput<'Microsoft.Resources/resourceGroups@2025-04-01'>.tags =
 
 var aiFoundryAiServicesAiProjectResourceName = 'proj-${solutionSuffix}'
 
+var deployerInfo = deployer()
 // ========== Resource Group Tag ========== //
 resource resourceGroupTags 'Microsoft.Resources/tags@2021-04-01' = {
   name: 'default'
@@ -184,6 +185,7 @@ resource resourceGroupTags 'Microsoft.Resources/tags@2021-04-01' = {
     tags: {
       ...tags
       TemplateName: 'Client Advisor'
+      CreatedBy: split(deployerInfo.userPrincipalName, '@')[0] 
     }
   }
 }


### PR DESCRIPTION
## Purpose
This pull request introduces a small enhancement to the resource group tagging in the infrastructure deployment. The main change is the addition of a new tag that identifies the creator of the deployment by extracting their username from the principal name.

* Resource Group Tagging:
  * [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R180-R188): Added a `CreatedBy` tag to resource group tags, using the deployer's username extracted from `deployer().userPrincipalName`.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [X] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here.. -->