### PR TITLE
feat: Create Separate User Assigned Identity for SQL DB with Specified Access

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -557,10 +557,6 @@ module keyvault 'br/public:avm/res/key-vault/vault:0.12.1' = {
           name: 'AZURE-SEARCH-ENDPOINT'
           value: 'https://${aiSearchName}.search.windows.net'
         }
-        {
-          name: 'SQLDB-USER-MID'
-          value: sqlUserAssignedIdentity.outputs.clientId
-        }
     ]
     enableTelemetry: enableTelemetry
   }
@@ -940,7 +936,6 @@ module sqlDBModule 'br/public:avm/res/sql/server:0.20.1' = {
       systemAssigned: true
       userAssignedResourceIds: [
         userAssignedIdentity.outputs.resourceId
-        sqlUserAssignedIdentity.outputs.resourceId
       ]
     }
     primaryUserAssignedIdentityResourceId: userAssignedIdentity.outputs.resourceId

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -463,7 +463,7 @@ var aiRelatedDnsZoneIndices = [
 @batchSize(5)
 module avmPrivateDnsZones 'br/public:avm/res/network/private-dns-zone:0.7.1' = [
   for (zone, i) in privateDnsZones: if (enablePrivateNetworking && (empty(existingFoundryProjectResourceId) || !contains(aiRelatedDnsZoneIndices, i))) {
-    name: 'dns-zone-${i}'
+    name: 'avm.res.network.private-dns-zone.${split(zone, '.')[1]}'
     params: {
       name: zone
       tags: tags
@@ -914,7 +914,11 @@ module sqlDBModule 'br/public:avm/res/sql/server:0.20.1' = {
     connectionPolicy: 'Redirect'
     databases: [
       {
-        availabilityZone: enableRedundancy ? 1 : -1
+        zoneRedundant: enableRedundancy ? true : false
+        // When enableRedundancy is true (zoneRedundant=true), set availabilityZone to -1
+        // to let Azure automatically manage zone placement across multiple zones.
+        // When enableRedundancy is false, also use -1 (no specific zone assignment).
+        availabilityZone: -1
         collation: 'SQL_Latin1_General_CP1_CI_AS'
         diagnosticSettings: enableMonitoring
           ? [{ workspaceResourceId: logAnalyticsWorkspaceResourceId }]

--- a/infra/scripts/process_sample_data.sh
+++ b/infra/scripts/process_sample_data.sh
@@ -8,8 +8,8 @@
 	keyvaultName="$5"
 	sqlServerName="$6"
 	SqlDatabaseName="$7"
-	webAppManagedIdentityClientId="$8"
-	webAppManagedIdentityDisplayName="$9"
+	sqlManagedIdentityClientId="$8"
+	sqlManagedIdentityDisplayName="$9"
 	aiSearchName="${10}"
 	aif_resource_id="${11}"
 
@@ -316,12 +316,14 @@
 		SqlDatabaseName=$(azd env get-value SQLDB_DATABASE)
 	fi
 
-	if [ -z "$webAppManagedIdentityClientId" ]; then
-		webAppManagedIdentityClientId=$(azd env get-value MANAGEDIDENTITY_WEBAPP_CLIENTID)
+	if [ -z "$sqlManagedIdentityClientId" ]; then
+		# Use the SQL-specific managed identity for database operations with limited permissions
+		sqlManagedIdentityClientId=$(azd env get-value MANAGEDIDENTITY_SQL_CLIENTID)
 	fi
 
-	if [ -z "$webAppManagedIdentityDisplayName" ]; then
-		webAppManagedIdentityDisplayName=$(azd env get-value MANAGEDIDENTITY_WEBAPP_NAME)
+	if [ -z "$sqlManagedIdentityDisplayName" ]; then
+		# Use the SQL-specific managed identity for database operations with limited permissions
+		sqlManagedIdentityDisplayName=$(azd env get-value MANAGEDIDENTITY_SQL_NAME)
 	fi
 
 	if [ -z "$aiSearchName" ]; then
@@ -335,8 +337,8 @@
 	azSubscriptionId=$(azd env get-value AZURE_SUBSCRIPTION_ID)
 
 	# Check if all required arguments are provided
-	if  [ -z "$resourceGroupName" ] || [ -z "$cosmosDbAccountName" ] || [ -z "$storageAccount" ] || [ -z "$fileSystem" ] || [ -z "$keyvaultName" ] || [ -z "$sqlServerName" ] || [ -z "$SqlDatabaseName" ] || [ -z "$webAppManagedIdentityClientId" ] || [ -z "$webAppManagedIdentityDisplayName" ] || [ -z "$aiSearchName" ] || [ -z "$aif_resource_id" ]; then
-		echo "Usage: $0 <resourceGroupName> <cosmosDbAccountName> <storageAccount> <storageContainerName> <keyvaultName> <sqlServerName> <sqlDatabaseName> <webAppUserManagedIdentityClientId> <webAppUserManagedIdentityDisplayName> <aiSearchName> <aiFoundryResourceGroup> <aif_resource_id>"
+	if  [ -z "$resourceGroupName" ] || [ -z "$cosmosDbAccountName" ] || [ -z "$storageAccount" ] || [ -z "$fileSystem" ] || [ -z "$keyvaultName" ] || [ -z "$sqlServerName" ] || [ -z "$SqlDatabaseName" ] || [ -z "$sqlManagedIdentityClientId" ] || [ -z "$sqlManagedIdentityDisplayName" ] || [ -z "$aiSearchName" ] || [ -z "$aif_resource_id" ]; then
+		echo "Usage: $0 <resourceGroupName> <cosmosDbAccountName> <storageAccount> <storageContainerName> <keyvaultName> <sqlServerName> <sqlDatabaseName> <sqlManagedIdentityClientId> <sqlManagedIdentityDisplayName> <aiSearchName> <aiFoundryResourceGroup> <aif_resource_id>"
 		exit 1
 	fi
 
@@ -437,8 +439,8 @@
 	# Call create_sql_user_and_role.sh
 	echo "Running create_sql_user_and_role.sh"
 	bash infra/scripts/add_user_scripts/create_sql_user_and_role.sh "$sqlServerName.database.windows.net" "$SqlDatabaseName" '[
-		{"clientId":"'"$webAppManagedIdentityClientId"'", "displayName":"'"$webAppManagedIdentityDisplayName"'", "role":"db_datareader"},
-		{"clientId":"'"$webAppManagedIdentityClientId"'", "displayName":"'"$webAppManagedIdentityDisplayName"'", "role":"db_datawriter"}
+		{"clientId":"'"$sqlManagedIdentityClientId"'", "displayName":"'"$sqlManagedIdentityDisplayName"'", "role":"db_datareader"},
+		{"clientId":"'"$sqlManagedIdentityClientId"'", "displayName":"'"$sqlManagedIdentityDisplayName"'", "role":"db_datawriter"}
 	]'
 	if [ $? -ne 0 ]; then
 		echo "Error: create_sql_user_and_role.sh failed."

--- a/src/App/backend/common/config.py
+++ b/src/App/backend/common/config.py
@@ -145,7 +145,6 @@ class Config:
         self.MID_ID = os.getenv("AZURE_CLIENT_ID")
         self.SQL_MID_ID = os.getenv("SQLDB_USER_MID")
 
-
         # System Prompts
         self.SQL_SYSTEM_PROMPT = os.environ.get("AZURE_SQL_SYSTEM_PROMPT")
         self.CALL_TRANSCRIPT_SYSTEM_PROMPT = os.environ.get(

--- a/src/App/backend/common/config.py
+++ b/src/App/backend/common/config.py
@@ -142,7 +142,9 @@ class Config:
         self.SQL_USERNAME = os.getenv("SQLDB_USERNAME")
         self.SQL_PASSWORD = os.getenv("SQLDB_PASSWORD")
         self.ODBC_DRIVER = "{ODBC Driver 18 for SQL Server}"
-        self.MID_ID = os.getenv("SQLDB_USER_MID")
+        self.MID_ID = os.getenv("AZURE_CLIENT_ID")
+        self.SQL_MID_ID = os.getenv("SQLDB_USER_MID")
+
 
         # System Prompts
         self.SQL_SYSTEM_PROMPT = os.environ.get("AZURE_SQL_SYSTEM_PROMPT")

--- a/src/App/backend/services/sqldb_service.py
+++ b/src/App/backend/services/sqldb_service.py
@@ -17,8 +17,7 @@ server = config.SQL_SERVER
 database = config.SQL_DATABASE
 username = config.SQL_USERNAME
 password = config.SQL_PASSWORD
-mid_id = config.MID_ID
-
+mid_id = config.SQL_MID_ID
 
 def dict_cursor(cursor):
     """

--- a/src/App/backend/services/sqldb_service.py
+++ b/src/App/backend/services/sqldb_service.py
@@ -19,6 +19,7 @@ username = config.SQL_USERNAME
 password = config.SQL_PASSWORD
 mid_id = config.SQL_MID_ID
 
+
 def dict_cursor(cursor):
     """
     Converts rows fetched by the cursor into a list of dictionaries.


### PR DESCRIPTION
## Purpose
This pull request introduces a dedicated user-assigned managed identity for SQL database operations with limited permissions, separating it from the web app's managed identity. The infrastructure, environment outputs, deployment scripts, and backend code are updated to consistently use this new SQL-specific identity for database access, improving security and permission scoping. Additionally, minor improvements are made to resource naming and redundancy settings.

**Managed Identity Separation and Security Improvements:**

* Added a new `sqlUserAssignedIdentity` resource in `infra/main.bicep` to serve as a dedicated managed identity for SQL operations, with limited permissions (`db_datareader`, `db_datawriter`).
* Updated the Key Vault access policy to grant the new SQL managed identity the `Key Vault Secrets User` role.
* Modified the web app deployment to assign both the general and SQL-specific managed identities, and updated the `SQLDB_USER_MID` environment variable to use the SQL identity's client ID. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L991-R1013) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L1038-R1060)

**Infrastructure and Output Adjustments:**

* Added outputs for the SQL managed identity's name and client ID, and clarified output descriptions. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R1251-R1256) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R1398-R1400)
* Updated the SQL database redundancy configuration to use `zoneRedundant` and clarified `availabilityZone` assignment for Azure best practices.
* Improved naming conventions for private DNS zone resources.

**Script and Backend Refactoring:**

* Refactored `process_sample_data.sh` to use the SQL managed identity for database operations, including argument names, environment variable lookups, and user/role assignment logic. [[1]](diffhunk://#diff-5f42277e379c1334fbdc9a52828c031d1620d82b99cded3dc825000a68e0ae0cL11-R12) [[2]](diffhunk://#diff-5f42277e379c1334fbdc9a52828c031d1620d82b99cded3dc825000a68e0ae0cL319-R326) [[3]](diffhunk://#diff-5f42277e379c1334fbdc9a52828c031d1620d82b99cded3dc825000a68e0ae0cL338-R341) [[4]](diffhunk://#diff-5f42277e379c1334fbdc9a52828c031d1620d82b99cded3dc825000a68e0ae0cL440-R443)
* Updated backend configuration (`config.py` and `sqldb_service.py`) to distinguish between the web app and SQL managed identities, using the correct identity for SQL authentication. [[1]](diffhunk://#diff-8fdf84d19472f411842e73b839b1e95373a19f40176ba7c65e676c75d7efb3edL145-R147) [[2]](diffhunk://#diff-42f37b2f18081a3a44cc215ed72549048a3265376381ca1bdadc1fc6edd4f33eL20-R20)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.