### PR TITLE
fix: Cross subscription issue while running post deployments scrip

### DIFF
--- a/infra/scripts/process_sample_data.sh
+++ b/infra/scripts/process_sample_data.sh
@@ -81,10 +81,13 @@
 		aif_resource_name=$(basename "$aif_account_resource_id")
 		# Extract resource group from the AI Foundry account resource ID
 		aif_resource_group=$(echo "$aif_account_resource_id" | sed -n 's|.*/resourceGroups/\([^/]*\)/.*|\1|p')
-		
+		# Extract subscription ID from the AI Foundry account resource ID
+    	aif_subscription_id=$(echo "$aif_account_resource_id" | sed -n 's|.*/subscriptions/\([^/]*\)/.*|\1|p')
+
 		original_foundry_public_access=$(az cognitiveservices account show \
 			--name "$aif_resource_name" \
 			--resource-group "$aif_resource_group" \
+			--subscription "$aif_subscription_id" \
 			--query "properties.publicNetworkAccess" \
 			--output tsv)
 		if [ -z "$original_foundry_public_access" ] || [ "$original_foundry_public_access" = "null" ]; then


### PR DESCRIPTION
## Purpose
This pull request updates the `process_sample_data.sh` script to improve how it interacts with Azure resources by correctly extracting and using the subscription ID from the AI Foundry account resource ID.

Azure resource handling improvements:

* The script now extracts the subscription ID (`aif_subscription_id`) from the AI Foundry account resource ID and uses it in the `az cognitiveservices account show` command to ensure the correct subscription context is set.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here.. -->